### PR TITLE
fix(update): include Sunday daily files and fix chain gap detection

### DIFF
--- a/crates/uls-download/src/client.rs
+++ b/crates/uls-download/src/client.rs
@@ -106,18 +106,10 @@ impl FccClient {
     }
 
     /// Download the daily license file for a specific date.
-    pub async fn download_daily_for_date(
-        &self,
-        service: &str,
-        date: NaiveDate,
-    ) -> Result<Option<PathBuf>> {
-        match ServiceCatalog::daily_license_for_date(service, date)? {
-            Some(file) => {
-                let (path, _) = self.download_file(&file, no_progress()).await?;
-                Ok(Some(path))
-            }
-            None => Ok(None), // No file for Sundays
-        }
+    pub async fn download_daily_for_date(&self, service: &str, date: NaiveDate) -> Result<PathBuf> {
+        let file = ServiceCatalog::daily_license_for_date(service, date)?;
+        let (path, _) = self.download_file(&file, no_progress()).await?;
+        Ok(path)
     }
 
     /// Download a specific data file.


### PR DESCRIPTION
## Summary

- **Sunday daily downloads were skipped** — vestigial development code omitted Sunday from the `Weekday` enum. The FCC publishes daily files all 7 days. Added `Sunday` variant, removed `Option` wrapping from `from_chrono`/`for_date`/`daily_license_for_date` since every day maps to a file, and removed the early-return in `get_missing_daily_files` that bailed on Sundays.
- **Daily chain falsely detected as broken** — `build_daily_chain` filtered out already-applied patches from `available_dailies` but started its continuity check from the weekly date. After a week of applied dailies, the gap between the weekly date and the first unapplied daily exceeded the threshold. Fixed by starting from the latest applied patch date. Also tightened the gap threshold from `> 2` to `> 1` since there's no Sunday gap to skip.