### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3](https://github.com/tgies/uls/compare/v0.1.2...v0.1.3) - 2026-02-23
+
+### Fixed
+
+- *(db)* prefer most recently granted record when no active license exists
+
 ## [0.1.2](https://github.com/tgies/uls/compare/v0.1.1...v0.1.2) - 2026-02-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uls-api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "chrono",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "uls-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "uls-db"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "uls-query"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,10 +80,10 @@ gungraun = "0.17"
 # Workspace crates
 uls-core = { path = "crates/uls-core", version = "0.1.1" }
 uls-parser = { path = "crates/uls-parser", version = "0.1.1" }
-uls-db = { path = "crates/uls-db", version = "0.1.1" }
+uls-db = { path = "crates/uls-db", version = "0.1.2" }
 uls-download = { path = "crates/uls-download", version = "0.2.0" }
-uls-api = { path = "crates/uls-api", version = "0.1.1" }
-uls-query = { path = "crates/uls-query", version = "0.1.1" }
+uls-api = { path = "crates/uls-api", version = "0.1.2" }
+uls-query = { path = "crates/uls-query", version = "0.1.2" }
 
 [profile.release]
 lto = true

--- a/crates/uls-api/Cargo.toml
+++ b/crates/uls-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-api"
 description = "REST API server for FCC ULS data access"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-cli/Cargo.toml
+++ b/crates/uls-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-cli"
 description = "CLI tool for FCC ULS data retrieval and management"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-db/Cargo.toml
+++ b/crates/uls-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-db"
 description = "SQLite database layer for FCC ULS data storage"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-query/Cargo.toml
+++ b/crates/uls-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-query"
 description = "Query engine for FCC ULS data lookups"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `uls-db`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `uls-cli`: 0.1.2 -> 0.1.3
* `uls-query`: 0.1.1 -> 0.1.2
* `uls-api`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>


## `uls-cli`

<blockquote>

## [0.1.3](https://github.com/tgies/uls/compare/v0.1.2...v0.1.3) - 2026-02-23

### Fixed

- *(db)* prefer most recently granted record when no active license exists
</blockquote>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).