### PR TITLE
fix(cli): correct update command in staleness warning

### DIFF
--- a/crates/uls-cli/src/staleness.rs
+++ b/crates/uls-cli/src/staleness.rs
@@ -99,7 +99,7 @@ pub fn print_staleness_warning(freshness: &DataFreshness) {
     };
 
     eprintln!(
-        "⚠ Data is {} old. Run 'uls update {}' to refresh.",
+        "⚠ Data is {} old. Run 'uls update --service {}' to refresh.",
         freshness.age_display, service_name
     );
     eprintln!("  (Use --no-stale-warning to suppress, or --auto-update to update automatically)");


### PR DESCRIPTION
## Summary
- Staleness warning suggested `uls update amateur` but CLI requires `uls update --service amateur`

Closes #10