### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4](https://github.com/tgies/uls/compare/v0.1.3...v0.1.4) - 2026-03-16
+
+### Added
+
+- *(query)* display PO Box in address output when available
+
+### Fixed
+
+- *(cli)* correct update command in staleness warning
+
+### Other
+
+- link online demo
+
 ## [0.1.3](https://github.com/tgies/uls/compare/v0.1.2...v0.1.3) - 2026-02-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,7 +2938,7 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uls-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "axum",
  "chrono",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "uls-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "uls-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "proptest",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "uls-db"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "uls-download"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -3041,7 +3041,7 @@ dependencies = [
 
 [[package]]
 name = "uls-parser"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "uls-query"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,12 +78,12 @@ criterion = { version = "0.5", features = ["html_reports"] }
 gungraun = "0.17"
 
 # Workspace crates
-uls-core = { path = "crates/uls-core", version = "0.1.1" }
-uls-parser = { path = "crates/uls-parser", version = "0.1.1" }
-uls-db = { path = "crates/uls-db", version = "0.1.2" }
-uls-download = { path = "crates/uls-download", version = "0.2.0" }
-uls-api = { path = "crates/uls-api", version = "0.1.2" }
-uls-query = { path = "crates/uls-query", version = "0.1.2" }
+uls-core = { path = "crates/uls-core", version = "0.1.2" }
+uls-parser = { path = "crates/uls-parser", version = "0.1.2" }
+uls-db = { path = "crates/uls-db", version = "0.2.0" }
+uls-download = { path = "crates/uls-download", version = "0.2.1" }
+uls-api = { path = "crates/uls-api", version = "0.1.3" }
+uls-query = { path = "crates/uls-query", version = "0.1.3" }
 
 [profile.release]
 lto = true

--- a/crates/uls-api/Cargo.toml
+++ b/crates/uls-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-api"
 description = "REST API server for FCC ULS data access"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-cli/Cargo.toml
+++ b/crates/uls-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-cli"
 description = "CLI tool for FCC ULS data retrieval and management"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-core/Cargo.toml
+++ b/crates/uls-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-core"
 description = "Core data types and models for FCC ULS data"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-db/Cargo.toml
+++ b/crates/uls-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-db"
 description = "SQLite database layer for FCC ULS data storage"
-version = "0.1.2"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-download/Cargo.toml
+++ b/crates/uls-download/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-download"
 description = "FCC ULS file download and synchronization"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-parser/Cargo.toml
+++ b/crates/uls-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-parser"
 description = "Parser for FCC ULS pipe-delimited DAT files"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-query/Cargo.toml
+++ b/crates/uls-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-query"
 description = "Query engine for FCC ULS data lookups"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `uls-core`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `uls-parser`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `uls-db`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)
* `uls-query`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `uls-api`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `uls-download`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `uls-cli`: 0.1.3 -> 0.1.4

### ⚠ `uls-db` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field License.po_box in /tmp/.tmpU6NcfH/uls/crates/uls-db/src/models.rs:45
  field License.po_box in /tmp/.tmpU6NcfH/uls/crates/uls-db/src/models.rs:45
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `uls-cli`

<blockquote>

## [0.1.4](https://github.com/tgies/uls/compare/v0.1.3...v0.1.4) - 2026-03-16

### Added

- *(query)* display PO Box in address output when available

### Fixed

- *(cli)* correct update command in staleness warning

### Other

- link online demo
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).