### PR TITLE
Display PO Box in address output

### DIFF
--- a/crates/uls-db/src/models.rs
+++ b/crates/uls-db/src/models.rs
@@ -41,6 +41,8 @@ pub struct License {
     pub state: Option<String>,
     /// ZIP code.
     pub zip_code: Option<String>,
+    /// PO Box.
+    pub po_box: Option<String>,
     /// Operator class (for amateur).
     pub operator_class: Option<char>,
     /// Previous call sign.
@@ -121,6 +123,7 @@ impl License {
                 }
             }
             "address" | "street_address" => self.street_address.clone(),
+            "po_box" => self.po_box.clone(),
             "frn" => self.frn.clone(),
             "grant_date" | "granted" => self.grant_date.map(|d| d.to_string()),
             "expired_date" | "expires" | "expiration" => self.expired_date.map(|d| d.to_string()),
@@ -148,6 +151,7 @@ impl License {
             "zip",
             "location",
             "address",
+            "po_box",
             "frn",
             "grant_date",
             "expired_date",
@@ -221,6 +225,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: Some('E'),
             previous_call_sign: None,
         };
@@ -250,6 +255,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: Some('E'),
             previous_call_sign: None,
         };
@@ -277,6 +283,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
@@ -324,6 +331,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: Some('T'),
             previous_call_sign: None,
         };
@@ -371,6 +379,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
@@ -397,6 +406,7 @@ mod tests {
             city: Some("Newington".to_string()),
             state: Some("CT".to_string()),
             zip_code: Some("06111".to_string()),
+            po_box: None,
             operator_class: Some('E'),
             previous_call_sign: Some("N1XYZ".to_string()),
         };
@@ -507,6 +517,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
@@ -534,6 +545,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
@@ -574,6 +586,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
@@ -608,6 +621,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
@@ -642,6 +656,7 @@ mod tests {
             city: Some("Boston".to_string()),
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
@@ -675,6 +690,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
@@ -705,6 +721,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
@@ -736,6 +753,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };

--- a/crates/uls-db/src/repository.rs
+++ b/crates/uls-db/src/repository.rs
@@ -373,13 +373,13 @@ impl Database {
 
         let result = conn.query_row(
             r#"
-            SELECT 
+            SELECT
                 l.unique_system_identifier, l.call_sign,
                 e.entity_name, e.first_name, e.middle_initial, e.last_name,
                 l.license_status, l.radio_service_code,
                 l.grant_date, l.expired_date, l.cancellation_date,
                 e.frn, NULL as previous_call_sign,
-                e.street_address, e.city, e.state, e.zip_code,
+                e.street_address, e.city, e.state, e.zip_code, e.po_box,
                 a.operator_class
             FROM licenses l
             LEFT JOIN entities e ON l.unique_system_identifier = e.unique_system_identifier
@@ -393,7 +393,7 @@ impl Database {
                 // Use centralized enum adapter helpers
                 let status = read_license_status(row, 6)?;
                 let radio_service = read_radio_service(row, 7)?;
-                let operator_class = read_operator_class(row, 17)?;
+                let operator_class = read_operator_class(row, 18)?;
 
                 Ok(License {
                     unique_system_identifier: row.get(0)?,
@@ -419,6 +419,7 @@ impl Database {
                     city: row.get(14)?,
                     state: row.get(15)?,
                     zip_code: row.get(16)?,
+                    po_box: row.get(17)?,
                     operator_class,
                 })
             },
@@ -439,13 +440,13 @@ impl Database {
 
         let mut stmt = conn.prepare(
             r#"
-            SELECT 
+            SELECT
                 l.unique_system_identifier, l.call_sign,
                 e.entity_name, e.first_name, e.middle_initial, e.last_name,
                 l.license_status, l.radio_service_code,
                 l.grant_date, l.expired_date, l.cancellation_date,
                 e.frn, NULL as previous_call_sign,
-                e.street_address, e.city, e.state, e.zip_code,
+                e.street_address, e.city, e.state, e.zip_code, e.po_box,
                 a.operator_class
             FROM licenses l
             INNER JOIN entities e ON l.unique_system_identifier = e.unique_system_identifier
@@ -460,7 +461,7 @@ impl Database {
             // Use centralized enum adapter helpers
             let status = read_license_status(row, 6)?;
             let radio_service = read_radio_service(row, 7)?;
-            let operator_class = read_operator_class(row, 17)?;
+            let operator_class = read_operator_class(row, 18)?;
 
             Ok(License {
                 unique_system_identifier: row.get(0)?,
@@ -486,6 +487,7 @@ impl Database {
                 city: row.get(14)?,
                 state: row.get(15)?,
                 zip_code: row.get(16)?,
+                po_box: row.get(17)?,
                 operator_class,
             })
         })?;

--- a/crates/uls-query/src/engine.rs
+++ b/crates/uls-query/src/engine.rs
@@ -68,13 +68,13 @@ impl QueryEngine {
 
         let query = format!(
             r#"
-            SELECT 
+            SELECT
                 l.unique_system_identifier, l.call_sign,
                 e.entity_name, e.first_name, e.middle_initial, e.last_name,
                 l.license_status, l.radio_service_code,
                 l.grant_date, l.expired_date, l.cancellation_date,
                 e.frn, NULL as previous_call_sign,
-                e.street_address, e.city, e.state, e.zip_code,
+                e.street_address, e.city, e.state, e.zip_code, e.po_box,
                 a.operator_class
             FROM licenses l
             LEFT JOIN entities e ON l.unique_system_identifier = e.unique_system_identifier
@@ -96,7 +96,7 @@ impl QueryEngine {
             // Use centralized enum adapter helpers from uls-db
             let status = read_license_status(row, 6)?;
             let radio_service = read_radio_service(row, 7)?;
-            let operator_class = read_operator_class(row, 17)?;
+            let operator_class = read_operator_class(row, 18)?;
 
             Ok(License {
                 unique_system_identifier: row.get(0)?,
@@ -122,6 +122,7 @@ impl QueryEngine {
                 city: row.get(14)?,
                 state: row.get(15)?,
                 zip_code: row.get(16)?,
+                po_box: row.get(17)?,
                 operator_class,
             })
         })?;

--- a/crates/uls-query/src/output.rs
+++ b/crates/uls-query/src/output.rs
@@ -88,8 +88,18 @@ fn format_license_table(license: &License) -> String {
         output.push_str(&format!("Operator Class: {}\n", class));
     }
 
-    if let Some(ref addr) = license.street_address {
-        output.push_str(&format!("Address:        {}\n", addr));
+    match (&license.street_address, &license.po_box) {
+        (Some(addr), Some(po_box)) => {
+            output.push_str(&format!("Address:        {}\n", addr));
+            output.push_str(&format!("                PO Box {}\n", po_box));
+        }
+        (Some(addr), None) => {
+            output.push_str(&format!("Address:        {}\n", addr));
+        }
+        (None, Some(po_box)) => {
+            output.push_str(&format!("Address:        PO Box {}\n", po_box));
+        }
+        (None, None) => {}
     }
 
     let location = format_location(license);
@@ -312,6 +322,7 @@ mod tests {
             city: Some("NEWINGTON".to_string()),
             state: Some("CT".to_string()),
             zip_code: Some("06111".to_string()),
+            po_box: None,
             operator_class: Some('E'),
             previous_call_sign: None,
         }
@@ -539,6 +550,7 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
@@ -581,12 +593,42 @@ mod tests {
             city: None,
             state: None,
             zip_code: None,
+            po_box: None,
             operator_class: None,
             previous_call_sign: None,
         };
         let output = license.format(OutputFormat::Table);
         assert!(output.contains("W0MIN"));
         // Should not have Location line since city/state/zip are all None
+    }
+
+    #[test]
+    fn test_table_format_po_box_fallback() {
+        let mut license = test_license();
+        license.street_address = None;
+        license.po_box = Some("608".to_string());
+        let output = license.format(OutputFormat::Table);
+        assert!(output.contains("Address:        PO Box 608"));
+        assert!(!output.contains("123 Main St"));
+    }
+
+    #[test]
+    fn test_table_format_both_address_and_po_box() {
+        let mut license = test_license();
+        license.street_address = Some("2865 Center Road".to_string());
+        license.po_box = Some("1367".to_string());
+        let output = license.format(OutputFormat::Table);
+        assert!(output.contains("Address:        2865 Center Road\n"));
+        assert!(output.contains("                PO Box 1367\n"));
+    }
+
+    #[test]
+    fn test_table_format_no_address_or_po_box() {
+        let mut license = test_license();
+        license.street_address = None;
+        license.po_box = None;
+        let output = license.format(OutputFormat::Table);
+        assert!(!output.contains("Address:"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Surface `entities.po_box` through the `License` model and all SQL query paths (callsign lookup, FRN lookup, search)
- Display PO Box in table output with proper fallback logic:
  - Street address only → `Address: <street>`
  - PO Box only → `Address: PO Box <po_box>`
  - Both present → street address on first line, `PO Box` on second (matches postal convention where last line takes delivery precedence)
- Expose `po_box` via `get_field("po_box")` for dynamic field access
- Include `po_box` in JSON/YAML serialization output via serde

## Example output

**PO Box only (the original reporter's case, K2QA):**
```
Call Sign:      K2QA
Name:           John K OConnell
Address:        PO Box 608
Location:       Mount Laurel, NJ 08054
```

**Both street address and PO Box (K0GK):**
```
Call Sign:      K0GK
Name:           Marvin L DE JONG
Address:        2865 Center Road
                PO Box 1367
Location:       Ozark, MO 65721
```

## Test plan

- [x] 366 existing tests pass
- [x] 3 new tests for PO Box display: fallback only, both present, neither present
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #11