### PR TITLE
feat(cli): add shell completion generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,6 +2974,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "clap_complete",
  "console",
  "csv",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ csv = "1.4"
 
 # CLI
 clap = { version = "4.5", features = ["derive", "env"] }
+clap_complete = "4.5"
 
 # HTTP client (using rustls to avoid OpenSSL dependency)
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls"] }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Additional FCC radio services are planned for future releases.
 | `uls stats` | Database statistics |
 | `uls serve` | Start REST API server |
 | `uls download` | Download FCC files without building database |
+| `uls completions <SHELL>` | Generate shell completions (bash, zsh, fish, elvish, powershell) |
 
 ## Configuration
 

--- a/crates/uls-cli/Cargo.toml
+++ b/crates/uls-cli/Cargo.toml
@@ -23,6 +23,7 @@ uls-download.workspace = true
 uls-query.workspace = true
 uls-api.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/uls-cli/src/commands/completions.rs
+++ b/crates/uls-cli/src/commands/completions.rs
@@ -1,0 +1,13 @@
+//! Shell completion generation.
+
+use std::io;
+
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+
+use crate::Cli;
+
+pub fn execute(shell: Shell) {
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "uls", &mut io::stdout());
+}

--- a/crates/uls-cli/src/commands/mod.rs
+++ b/crates/uls-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! CLI command modules.
 
 pub mod auto_update;
+pub mod completions;
 pub mod db;
 pub mod frn;
 pub mod lookup;

--- a/crates/uls-cli/src/main.rs
+++ b/crates/uls-cli/src/main.rs
@@ -11,6 +11,7 @@
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use clap_complete::Shell;
 use tracing_subscriber::EnvFilter;
 
 mod commands;
@@ -123,6 +124,13 @@ enum Commands {
         /// CORS allowed origin (repeatable)
         #[arg(long = "cors-origin")]
         cors_origins: Vec<String>,
+    },
+
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: Shell,
     },
 
     /// Manage the database
@@ -321,6 +329,10 @@ async fn main() -> Result<()> {
             bind,
             cors_origins,
         }) => commands::serve::execute(port, &bind, cors_origins).await,
+        Some(Commands::Completions { shell }) => {
+            commands::completions::execute(shell);
+            Ok(())
+        }
         Some(Commands::Db { command }) => match command {
             DbCommands::Init { path } => commands::db::init(path).await,
             DbCommands::Info => commands::db::info(&cli.format).await,

--- a/crates/uls-cli/tests/cli_integration.rs
+++ b/crates/uls-cli/tests/cli_integration.rs
@@ -380,6 +380,70 @@ fn test_multi_frn_partial_failure() {
 }
 
 // =============================================================================
+// Shell completions tests
+// =============================================================================
+
+#[test]
+fn test_completions_bash() {
+    Command::cargo_bin("uls")
+        .unwrap()
+        .args(["completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete"));
+}
+
+#[test]
+fn test_completions_zsh() {
+    Command::cargo_bin("uls")
+        .unwrap()
+        .args(["completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("compdef").or(predicate::str::contains("_uls")));
+}
+
+#[test]
+fn test_completions_fish() {
+    Command::cargo_bin("uls")
+        .unwrap()
+        .args(["completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete"));
+}
+
+#[test]
+fn test_completions_elvish() {
+    Command::cargo_bin("uls")
+        .unwrap()
+        .args(["completions", "elvish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+}
+
+#[test]
+fn test_completions_powershell() {
+    Command::cargo_bin("uls")
+        .unwrap()
+        .args(["completions", "powershell"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("uls"));
+}
+
+#[test]
+fn test_completions_help() {
+    Command::cargo_bin("uls")
+        .unwrap()
+        .args(["completions", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("shell"));
+}
+
+// =============================================================================
 // Database management tests
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- Add `uls completions <shell>` subcommand for generating shell completions
- Supports bash, zsh, fish, elvish, and powershell via `clap_complete`
- Standard pattern: pipe output to the appropriate completions directory

### Usage

```bash
# Bash
uls completions bash > /etc/bash_completion.d/uls

# Zsh
uls completions zsh > ~/.zfunc/_uls

# Fish
uls completions fish > ~/.config/fish/completions/uls.fish
```

## Test plan

- [x] Integration tests for all 5 shell types (bash, zsh, fish, elvish, powershell)
- [x] Help text test for `uls completions --help`
- [x] Full test suite passes (372 tests, 0 failures)
- [x] Clippy clean with `-D warnings`