### PR TITLE
fix(cli): use sort_by_key for license dedup sort

### DIFF
--- a/crates/uls-cli/src/commands/lookup.rs
+++ b/crates/uls-cli/src/commands/lookup.rs
@@ -112,7 +112,7 @@ pub async fn execute(
     }
 
     // Deduplicate by unique_system_identifier
-    all_licenses.sort_by(|a, b| a.unique_system_identifier.cmp(&b.unique_system_identifier));
+    all_licenses.sort_by_key(|a| a.unique_system_identifier);
     all_licenses.dedup_by(|a, b| a.unique_system_identifier == b.unique_system_identifier);
 
     // Sort so originally-requested callsigns appear first


### PR DESCRIPTION
Clippy on Rust 1.96.0 now flags the manual `sort_by` closure in `lookup.rs` with `clippy::unnecessary_sort_by`, failing CI on main. `unique_system_identifier` is `i64` (Copy), so `sort_by_key` takes it by value.

Pre-existing code; surfaced when the CI runner's clippy toolchain advanced, not by any recent change.