### PR TITLE
fix(db): scope weekly metadata query connection to avoid pool deadlock

### DIFF
--- a/crates/uls-db/src/repository.rs
+++ b/crates/uls-db/src/repository.rs
@@ -688,12 +688,16 @@ impl Database {
             threshold_days,
         );
 
-        // Get last weekly date from metadata
+        // Get last weekly date from metadata. Scope the connection so it returns
+        // to the pool before get_applied_patches checks out another one; holding
+        // two pooled connections on one thread can exhaust the pool and deadlock.
         let weekly_key = format!("last_weekly_date_{}", service);
-        let conn = self.conn()?;
-        if let Some(date_str) = Schema::get_metadata(&conn, &weekly_key)? {
-            freshness.last_weekly_date =
-                chrono::NaiveDate::parse_from_str(&date_str, "%Y-%m-%d").ok();
+        {
+            let conn = self.conn()?;
+            if let Some(date_str) = Schema::get_metadata(&conn, &weekly_key)? {
+                freshness.last_weekly_date =
+                    chrono::NaiveDate::parse_from_str(&date_str, "%Y-%m-%d").ok();
+            }
         }
 
         // Get applied patches


### PR DESCRIPTION
`Database::get_freshness` checked out a pooled connection for the weekly-metadata query and held it while calling `get_applied_patches`, which checks out a second connection. With the default 4-connection pool, four concurrent callers each holding their first connection and waiting for a second exhaust the pool and deadlock; with a single-connection (in-memory) pool it deadlocks even single-threaded.

Scopes the metadata connection in a block so it returns to the pool before `get_applied_patches` runs, so at most one connection is held per call. This also lets freshness/query tests run against `DatabaseConfig::in_memory()`.