### PR TITLE
fix(download): send versioned default User-Agent on invalid-config fallback

### DIFF
--- a/crates/uls-download/src/client.rs
+++ b/crates/uls-download/src/client.rs
@@ -36,7 +36,7 @@ impl FccClient {
             config
                 .user_agent
                 .parse()
-                .unwrap_or_else(|_| "uls-cli/0.1.0".parse().unwrap()),
+                .unwrap_or_else(|_| crate::config::DEFAULT_USER_AGENT.parse().unwrap()),
         );
 
         let http = reqwest::Client::builder()

--- a/crates/uls-download/src/config.rs
+++ b/crates/uls-download/src/config.rs
@@ -3,6 +3,15 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+/// Default User-Agent sent with FCC download requests, carrying the crate
+/// version. Also used as the fallback when a configured User-Agent cannot be
+/// parsed into a header value.
+pub const DEFAULT_USER_AGENT: &str = concat!(
+    "uls-cli/",
+    env!("CARGO_PKG_VERSION"),
+    " (https://github.com/tgies/uls)"
+);
+
 /// Configuration for the FCC download client.
 #[derive(Debug, Clone)]
 pub struct DownloadConfig {
@@ -37,10 +46,7 @@ impl Default for DownloadConfig {
             cache_dir: default_cache_dir(),
             base_url: "https://data.fcc.gov/download/pub/uls".to_string(),
             timeout: Duration::from_secs(300), // 5 minutes
-            user_agent: format!(
-                "uls-cli/{} (https://github.com/tgies/uls)",
-                env!("CARGO_PKG_VERSION")
-            ),
+            user_agent: DEFAULT_USER_AGENT.to_string(),
             verify_ssl: true,
             max_retries: 3,
             retry_delay: Duration::from_secs(5),


### PR DESCRIPTION
When a configured User-Agent can't be parsed into a header value, `FccClient::new` fell back to a hardcoded `uls-cli/0.1.0`, which is stale (the crate is at 0.2.1) and omits the `(https://github.com/tgies/uls)` suffix the real default carries.

Adds a `DEFAULT_USER_AGENT` constant built from `CARGO_PKG_VERSION`, used by both the config default and the fallback, so the fallback always matches the current default.