### PR TITLE
test: increase coverage to ~96% across all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2993,6 +2993,7 @@ dependencies = [
  "uls-download",
  "uls-parser",
  "uls-query",
+ "wiremock",
  "zip",
 ]
 

--- a/crates/uls-api/src/error.rs
+++ b/crates/uls-api/src/error.rs
@@ -62,3 +62,104 @@ impl IntoResponse for ApiError {
         (status, Json(body)).into_response()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    /// Read a response body as parsed JSON.
+    async fn json_body(resp: Response) -> serde_json::Value {
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn not_found_maps_to_404_with_message() {
+        let resp = ApiError::NotFound("missing W1XYZ".to_string()).into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let body = json_body(resp).await;
+        assert_eq!(body["error"], "not_found");
+        assert_eq!(body["message"], "missing W1XYZ");
+    }
+
+    #[tokio::test]
+    async fn bad_request_maps_to_400_with_message() {
+        let resp = ApiError::BadRequest("bad input".to_string()).into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let body = json_body(resp).await;
+        assert_eq!(body["error"], "bad_request");
+        assert_eq!(body["message"], "bad input");
+    }
+
+    #[tokio::test]
+    async fn not_initialized_maps_to_503_with_static_message() {
+        let resp = ApiError::NotInitialized.into_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let body = json_body(resp).await;
+        assert_eq!(body["error"], "not_initialized");
+        assert_eq!(
+            body["message"],
+            "Database not initialized. Run 'uls update' first."
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_maps_to_500_with_message() {
+        let resp = ApiError::Internal("boom".to_string()).into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let body = json_body(resp).await;
+        assert_eq!(body["error"], "internal_error");
+        assert_eq!(body["message"], "boom");
+    }
+
+    #[test]
+    fn query_error_not_initialized_converts_to_api_not_initialized() {
+        let api: ApiError = uls_query::QueryError::NotInitialized.into();
+        assert!(matches!(api, ApiError::NotInitialized));
+    }
+
+    #[test]
+    fn query_error_other_converts_to_internal_preserving_message() {
+        // A query against an in-memory database with no schema returns a
+        // non-NotInitialized QueryError (a SQLite "no such table" error),
+        // which the conversion maps to ApiError::Internal.
+        let db = uls_db::Database::with_config(uls_db::DatabaseConfig::in_memory()).unwrap();
+        let engine = uls_query::QueryEngine::with_database(db);
+        let err = engine
+            .lookup("W1AW")
+            .expect_err("lookup on uninitialized schema should error");
+        assert!(!matches!(err, uls_query::QueryError::NotInitialized));
+
+        let display = err.to_string();
+        let api: ApiError = err.into();
+        match api {
+            ApiError::Internal(msg) => assert_eq!(msg, display),
+            other => panic!("expected Internal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn error_display_includes_variant_context() {
+        assert_eq!(
+            ApiError::NotFound("x".to_string()).to_string(),
+            "not found: x"
+        );
+        assert_eq!(
+            ApiError::BadRequest("y".to_string()).to_string(),
+            "bad request: y"
+        );
+        assert_eq!(
+            ApiError::NotInitialized.to_string(),
+            "database not initialized"
+        );
+        assert_eq!(
+            ApiError::Internal("z".to_string()).to_string(),
+            "internal error: z"
+        );
+    }
+}

--- a/crates/uls-api/tests/api_tests.rs
+++ b/crates/uls-api/tests/api_tests.rs
@@ -6,7 +6,7 @@ use chrono::NaiveDate;
 use tower::ServiceExt;
 use uls_api::server::build_router;
 use uls_api::ServerConfig;
-use uls_core::records::{EntityRecord, HeaderRecord, UlsRecord};
+use uls_core::records::{AmateurRecord, EntityRecord, HeaderRecord, UlsRecord};
 use uls_db::{Database, DatabaseConfig};
 use uls_query::QueryEngine;
 
@@ -52,6 +52,113 @@ fn test_engine_with_data() -> QueryEngine {
     QueryEngine::with_database(db)
 }
 
+/// Create a test query engine with one Extra-class amateur (HA) license, for
+/// service- and class-filter tests.
+fn test_engine_with_amateur() -> QueryEngine {
+    let config = DatabaseConfig::in_memory();
+    let db = Database::with_config(config).unwrap();
+    db.initialize().unwrap();
+
+    let mut header = HeaderRecord::from_fields(&["HD", "999"]);
+    header.unique_system_identifier = 999;
+    header.call_sign = Some("K9EXTRA".to_string());
+    header.license_status = Some('A');
+    header.radio_service_code = Some("HA".to_string());
+    header.grant_date = Some(NaiveDate::from_ymd_opt(2021, 6, 1).unwrap());
+    header.expired_date = Some(NaiveDate::from_ymd_opt(2031, 6, 1).unwrap());
+    db.insert_record(&UlsRecord::Header(header)).unwrap();
+
+    let mut entity = EntityRecord::from_fields(&["EN", "999"]);
+    entity.unique_system_identifier = 999;
+    entity.entity_name = Some("EXTRA OP".to_string());
+    entity.last_name = Some("OP".to_string());
+    entity.state = Some("TX".to_string());
+    entity.city = Some("AUSTIN".to_string());
+    entity.zip_code = Some("78701".to_string());
+    entity.frn = Some("0009998888".to_string());
+    db.insert_record(&UlsRecord::Entity(entity)).unwrap();
+
+    let mut amateur = AmateurRecord::from_fields(&["AM", "999"]);
+    amateur.unique_system_identifier = 999;
+    amateur.callsign = Some("K9EXTRA".to_string());
+    amateur.operator_class = Some('E');
+    db.insert_record(&UlsRecord::Amateur(amateur)).unwrap();
+
+    QueryEngine::with_database(db)
+}
+
+/// Create a test query engine with two rows in different cities/states, for
+/// city, filter-expression, and sort tests.
+fn test_engine_two_cities() -> QueryEngine {
+    let config = DatabaseConfig::in_memory();
+    let db = Database::with_config(config).unwrap();
+    db.initialize().unwrap();
+
+    // Row 1: W1TEST in NEWINGTON, CT.
+    let mut header1 = HeaderRecord::from_fields(&["HD", "1"]);
+    header1.unique_system_identifier = 1;
+    header1.call_sign = Some("W1TEST".to_string());
+    header1.license_status = Some('A');
+    header1.radio_service_code = Some("HA".to_string());
+    header1.grant_date = Some(NaiveDate::from_ymd_opt(2020, 2, 15).unwrap());
+    db.insert_record(&UlsRecord::Header(header1)).unwrap();
+
+    let mut entity1 = EntityRecord::from_fields(&["EN", "1"]);
+    entity1.unique_system_identifier = 1;
+    entity1.entity_name = Some("ALPHA USER".to_string());
+    entity1.last_name = Some("USER".to_string());
+    entity1.state = Some("CT".to_string());
+    entity1.city = Some("NEWINGTON".to_string());
+    entity1.frn = Some("0001234567".to_string());
+    db.insert_record(&UlsRecord::Entity(entity1)).unwrap();
+
+    // Row 2: K2OTHER in BOSTON, MA.
+    let mut header2 = HeaderRecord::from_fields(&["HD", "2"]);
+    header2.unique_system_identifier = 2;
+    header2.call_sign = Some("K2OTHER".to_string());
+    header2.license_status = Some('A');
+    header2.radio_service_code = Some("HA".to_string());
+    header2.grant_date = Some(NaiveDate::from_ymd_opt(2020, 2, 15).unwrap());
+    db.insert_record(&UlsRecord::Header(header2)).unwrap();
+
+    let mut entity2 = EntityRecord::from_fields(&["EN", "2"]);
+    entity2.unique_system_identifier = 2;
+    entity2.entity_name = Some("BRAVO PERSON".to_string());
+    entity2.last_name = Some("PERSON".to_string());
+    entity2.state = Some("MA".to_string());
+    entity2.city = Some("BOSTON".to_string());
+    entity2.frn = Some("0007654321".to_string());
+    db.insert_record(&UlsRecord::Entity(entity2)).unwrap();
+
+    QueryEngine::with_database(db)
+}
+
+/// Build an engine from (usi, call_sign, entity_name, license_status) rows
+/// (all HA service, granted 2020-02-15) for discriminating name/status filter
+/// tests that need a non-matching row to prove exclusion.
+fn engine_with_rows(rows: &[(i64, &str, &str, char)]) -> QueryEngine {
+    let config = DatabaseConfig::in_memory();
+    let db = Database::with_config(config).unwrap();
+    db.initialize().unwrap();
+
+    for &(usi, call, name, status) in rows {
+        let mut header = HeaderRecord::from_fields(&["HD", "0"]);
+        header.unique_system_identifier = usi;
+        header.call_sign = Some(call.to_string());
+        header.license_status = Some(status);
+        header.radio_service_code = Some("HA".to_string());
+        header.grant_date = Some(NaiveDate::from_ymd_opt(2020, 2, 15).unwrap());
+        db.insert_record(&UlsRecord::Header(header)).unwrap();
+
+        let mut entity = EntityRecord::from_fields(&["EN", "0"]);
+        entity.unique_system_identifier = usi;
+        entity.entity_name = Some(name.to_string());
+        db.insert_record(&UlsRecord::Entity(entity)).unwrap();
+    }
+
+    QueryEngine::with_database(db)
+}
+
 fn server_config() -> ServerConfig {
     ServerConfig::default()
 }
@@ -61,6 +168,19 @@ async fn body_bytes(body: Body) -> Vec<u8> {
     use http_body_util::BodyExt;
     let collected = body.collect().await.unwrap();
     collected.to_bytes().to_vec()
+}
+
+/// Helper: GET `uri` against a freshly built router and return (status, json body).
+async fn get_json(engine: QueryEngine, uri: &str) -> (StatusCode, serde_json::Value) {
+    let app = build_router(engine, &server_config());
+    let resp = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = body_bytes(resp.into_body()).await;
+    let json = serde_json::from_slice(&bytes).unwrap();
+    (status, json)
 }
 
 // ---------------------------------------------------------------------------
@@ -254,4 +374,410 @@ async fn test_search_with_limit() {
     let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
     assert_eq!(json["limit"], 10);
     assert_eq!(json["offset"], 0);
+}
+
+// ---------------------------------------------------------------------------
+// FRN handler branches
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_frn_valid_format_but_no_match_is_404() {
+    // Ten digits, well-formed, but no licensee carries this FRN.
+    let (status, json) = get_json(test_engine_with_data(), "/frn/9999999999").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(json["error"], "not_found");
+    assert!(json["message"].as_str().unwrap().contains("9999999999"));
+}
+
+#[tokio::test]
+async fn test_frn_too_short_is_400() {
+    let (status, json) = get_json(test_engine(), "/frn/123").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["error"], "bad_request");
+    assert_eq!(json["message"], "FRN must be exactly 10 digits");
+}
+
+#[tokio::test]
+async fn test_frn_non_digit_ten_chars_is_400() {
+    // Length is right but contains a non-digit, so the digit check rejects it.
+    let (status, json) = get_json(test_engine(), "/frn/00012345AB").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["error"], "bad_request");
+}
+
+#[tokio::test]
+async fn test_frn_response_has_zero_pagination_fields() {
+    let (status, json) = get_json(test_engine_with_data(), "/frn/0001234567").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["limit"], 0);
+    assert_eq!(json["offset"], 0);
+    assert_eq!(json["count"], 1);
+}
+
+// ---------------------------------------------------------------------------
+// Search query-param branches
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_search_unknown_service_is_400() {
+    let (status, json) = get_json(test_engine_with_data(), "/licenses?service=walkie").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(json["error"], "bad_request");
+    assert!(json["message"].as_str().unwrap().contains("walkie"));
+}
+
+#[tokio::test]
+async fn test_search_service_amateur_matches_ha() {
+    let (status, json) = get_json(test_engine_with_amateur(), "/licenses?service=amateur").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["data"][0]["call_sign"], "K9EXTRA");
+}
+
+#[tokio::test]
+async fn test_search_service_gmrs_excludes_amateur() {
+    // The only row is an HA license, so a GMRS (ZA) filter yields nothing.
+    let (status, json) = get_json(test_engine_with_amateur(), "/licenses?service=gmrs").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 0);
+}
+
+#[tokio::test]
+async fn test_search_by_callsign() {
+    let (status, json) = get_json(test_engine_with_data(), "/licenses?callsign=W1TEST").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["data"][0]["call_sign"], "W1TEST");
+}
+
+#[tokio::test]
+async fn test_search_by_frn_param() {
+    let (status, json) = get_json(test_engine_with_data(), "/licenses?frn=0001234567").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["data"][0]["frn"], "0001234567");
+}
+
+#[tokio::test]
+async fn test_search_by_city() {
+    // city=NEWINGTON must match only the Newington row, not the Boston one.
+    let (status, json) = get_json(test_engine_two_cities(), "/licenses?city=NEWINGTON").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["data"][0]["city"], "NEWINGTON");
+    assert_eq!(json["data"][0]["call_sign"], "W1TEST");
+}
+
+#[tokio::test]
+async fn test_search_no_filter_returns_all_rows() {
+    // With no filter, both rows come back.
+    let (status, json) = get_json(test_engine_two_cities(), "/licenses").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 2);
+}
+
+#[tokio::test]
+async fn test_search_by_zip() {
+    let (status, json) = get_json(test_engine_with_amateur(), "/licenses?zip=78701").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["data"][0]["zip_code"], "78701");
+}
+
+#[tokio::test]
+async fn test_search_by_status_active() {
+    // Single-char status is uppercased; the sample row is status 'A'.
+    let (status, json) = get_json(test_engine_with_data(), "/licenses?status=a").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+}
+
+#[tokio::test]
+async fn test_search_by_status_no_match() {
+    let (status, json) = get_json(test_engine_with_data(), "/licenses?status=X").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 0);
+}
+
+#[tokio::test]
+async fn test_search_by_operator_class() {
+    let (status, json) = get_json(test_engine_with_amateur(), "/licenses?class=e").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["data"][0]["call_sign"], "K9EXTRA");
+}
+
+#[tokio::test]
+async fn test_search_name_plain_is_wrapped_in_wildcards() {
+    // A name without glob chars is wrapped as *NAME* and matches a substring.
+    let (status, json) = get_json(test_engine_with_data(), "/licenses?name=USER").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+}
+
+#[tokio::test]
+async fn test_search_name_with_glob_passed_through() {
+    // `name=TEST*` is used as the LIKE pattern as-is (TEST%), matching only names
+    // that start with TEST. "CONTEST CLUB" has TEST as an interior substring and
+    // must be excluded; a double-wrapped pattern (%TEST%%) would wrongly include it.
+    let engine = engine_with_rows(&[
+        (1, "W1AAA", "TEST USER", 'A'),
+        (2, "W2BBB", "CONTEST CLUB", 'A'),
+    ]);
+    let (status, json) = get_json(engine, "/licenses?name=TEST*").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["data"][0]["call_sign"], "W1AAA");
+}
+
+#[tokio::test]
+async fn test_search_active_only_flag() {
+    // active=true filters to license_status 'A', excluding the expired ('E') row.
+    let engine = engine_with_rows(&[
+        (1, "W1AAA", "ACTIVE OP", 'A'),
+        (2, "W2BBB", "EXPIRED OP", 'E'),
+    ]);
+    let (status, json) = get_json(engine, "/licenses?active=true").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["data"][0]["call_sign"], "W1AAA");
+}
+
+#[tokio::test]
+async fn test_search_filter_expression() {
+    // Two rows differ by state; the filter clause must exclude the MA row.
+    let (status, json) = get_json(test_engine_two_cities(), "/licenses?filter=state=CT").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["data"][0]["call_sign"], "W1TEST");
+}
+
+#[tokio::test]
+async fn test_search_filter_only_empty_segments_is_no_filter() {
+    // Filter segments that are only empty/whitespace add no clause, so both
+    // rows survive.
+    let (status, json) = get_json(test_engine_two_cities(), "/licenses?filter=,,,%20,%20").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 2);
+}
+
+#[tokio::test]
+async fn test_search_filter_empty_segments_around_valid_clause() {
+    // Empty segments are skipped; the surviving state=CT clause excludes the MA row.
+    let (status, json) =
+        get_json(test_engine_two_cities(), "/licenses?filter=,state=CT,%20,").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["data"][0]["call_sign"], "W1TEST");
+}
+
+#[tokio::test]
+async fn test_search_sort_field_orders_rows() {
+    // Ascending sort by call_sign orders K2OTHER before W1TEST.
+    let (status, json) = get_json(test_engine_two_cities(), "/licenses?sort=call_sign").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 2);
+    assert_eq!(json["data"][0]["call_sign"], "K2OTHER");
+    assert_eq!(json["data"][1]["call_sign"], "W1TEST");
+}
+
+#[tokio::test]
+async fn test_search_sort_field_descending() {
+    // A leading '-' flips the order so W1TEST sorts first.
+    let (status, json) = get_json(test_engine_two_cities(), "/licenses?sort=-call_sign").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 2);
+    assert_eq!(json["data"][0]["call_sign"], "W1TEST");
+    assert_eq!(json["data"][1]["call_sign"], "K2OTHER");
+}
+
+#[tokio::test]
+async fn test_search_limit_clamped_to_max() {
+    // Requested limit above MAX_LIMIT (1000) is clamped to 1000 in the response.
+    let (status, json) = get_json(test_engine_with_data(), "/licenses?limit=99999").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["limit"], 1000);
+}
+
+#[tokio::test]
+async fn test_search_default_limit_applied() {
+    // No limit param yields the DEFAULT_LIMIT of 50.
+    let (status, json) = get_json(test_engine_with_data(), "/licenses?state=CT").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["limit"], 50);
+}
+
+#[tokio::test]
+async fn test_search_offset_applied() {
+    // Offset past the single row yields an empty page but echoes the offset.
+    let (status, json) = get_json(test_engine_with_data(), "/licenses?state=CT&offset=5").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["offset"], 5);
+    assert_eq!(json["count"], 0);
+}
+
+#[tokio::test]
+async fn test_search_bad_limit_type_is_400() {
+    // A non-numeric limit fails Query extraction before the handler runs.
+    let app = build_router(test_engine_with_data(), &server_config());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/licenses?limit=notanumber")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_search_granted_after_filter() {
+    // Sample grant date is 2020-02-15, so an earlier bound keeps the row.
+    let (status, json) = get_json(
+        test_engine_with_data(),
+        "/licenses?granted_after=2019-01-01",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 1);
+}
+
+#[tokio::test]
+async fn test_search_granted_after_excludes_older() {
+    let (status, json) = get_json(
+        test_engine_with_data(),
+        "/licenses?granted_after=2025-01-01",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["count"], 0);
+}
+
+// ---------------------------------------------------------------------------
+// Stats handler with data
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_stats_counts_loaded_license() {
+    let (status, json) = get_json(test_engine_with_data(), "/stats").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(json["total_licenses"], 1);
+}
+
+// ---------------------------------------------------------------------------
+// Router wiring / ServerConfig (server.rs)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn server_config_default_values() {
+    let config = ServerConfig::default();
+    assert_eq!(config.bind, "127.0.0.1");
+    assert_eq!(config.port, 3000);
+    assert!(config.cors_origins.is_empty());
+}
+
+#[tokio::test]
+async fn test_unknown_route_is_404() {
+    let app = build_router(test_engine(), &server_config());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/does-not-exist")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_known_routes_are_wired() {
+    // Each declared route returns 200 on the pre-loaded engine, not a 404.
+    for uri in [
+        "/health",
+        "/stats",
+        "/licenses",
+        "/licenses/W1TEST",
+        "/frn/0001234567",
+    ] {
+        let app = build_router(test_engine_with_data(), &server_config());
+        let resp = app
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "route {uri} should be wired");
+    }
+}
+
+#[tokio::test]
+async fn test_cors_wildcard_layer_adds_allow_origin_header() {
+    let config = ServerConfig {
+        cors_origins: vec!["*".to_string()],
+        ..ServerConfig::default()
+    };
+    let app = build_router(test_engine(), &config);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .header("origin", "https://anything.test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get("access-control-allow-origin")
+            .and_then(|v| v.to_str().ok()),
+        Some("*")
+    );
+}
+
+#[tokio::test]
+async fn test_cors_specific_origin_layer_echoes_allowed_origin() {
+    let config = ServerConfig {
+        cors_origins: vec!["https://allowed.test".to_string()],
+        ..ServerConfig::default()
+    };
+    let app = build_router(test_engine(), &config);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .header("origin", "https://allowed.test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get("access-control-allow-origin")
+            .and_then(|v| v.to_str().ok()),
+        Some("https://allowed.test")
+    );
+}
+
+#[tokio::test]
+async fn test_no_cors_layer_when_origins_empty() {
+    let config = ServerConfig::default();
+    let app = build_router(test_engine(), &config);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .header("origin", "https://anything.test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(resp.headers().get("access-control-allow-origin").is_none());
 }

--- a/crates/uls-cli/Cargo.toml
+++ b/crates/uls-cli/Cargo.toml
@@ -42,3 +42,4 @@ rstest.workspace = true
 assert_cmd = "2.0"
 predicates = "3.1"
 zip.workspace = true
+wiremock.workspace = true

--- a/crates/uls-cli/src/commands/update.rs
+++ b/crates/uls-cli/src/commands/update.rs
@@ -487,4 +487,402 @@ mod tests {
         let kept = weekdays_to_check(None);
         assert_eq!(kept.len(), 7);
     }
+
+    // =========================================================================
+    // Orchestration tests (run_update / apply_weekly / build_daily_chain /
+    // apply_dailies) driven by a wiremock backend and a real TempDir database.
+    // =========================================================================
+
+    use std::fs;
+    use std::io::Write as _;
+    use std::path::Path;
+    use tempfile::TempDir;
+    use uls_download::DownloadConfig;
+    use wiremock::matchers::{method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    /// Path to the shared FCC sample fixtures.
+    fn fixture_dir(service: &str) -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("tests/fixtures/fcc-sample")
+            .join(service)
+    }
+
+    /// Build a ULS ZIP from the fixture DAT files plus a `counts` file carrying
+    /// the given FCC creation date string. The creation date is what
+    /// `extract_canonical_date` reads to order/gate weekly and daily files.
+    fn build_fixture_zip(service: &str, creation_date: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let cursor = std::io::Cursor::new(&mut buf);
+            let mut zip = ZipWriter::new(cursor);
+            let opts =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+            zip.start_file("counts", opts).unwrap();
+            writeln!(zip, "File Creation Date: {}", creation_date).unwrap();
+
+            for entry in fs::read_dir(fixture_dir(service)).unwrap() {
+                let p = entry.unwrap().path();
+                if p.extension().is_some_and(|e| e == "dat") {
+                    let name = p.file_name().unwrap().to_str().unwrap().to_string();
+                    let contents = fs::read(&p).unwrap();
+                    zip.start_file(name, opts).unwrap();
+                    zip.write_all(&contents).unwrap();
+                }
+            }
+            zip.finish().unwrap();
+        }
+        buf
+    }
+
+    /// Mount a ZIP body at the given URL path on the mock server.
+    async fn mount_zip(server: &MockServer, url_path: &str, body: Vec<u8>) {
+        Mock::given(method("GET"))
+            .and(wm_path(url_path.to_string()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(body.clone())
+                    .insert_header("Content-Length", body.len().to_string())
+                    .insert_header("ETag", "\"fixture-etag\""),
+            )
+            .mount(server)
+            .await;
+    }
+
+    /// Open a fresh initialized database in a temp directory.
+    fn fresh_db(dir: &Path) -> Database {
+        let config = DatabaseConfig::with_path(dir.join("test.db"));
+        let db = Database::with_config(config).unwrap();
+        db.initialize().unwrap();
+        db
+    }
+
+    fn test_client(server: &MockServer, cache: &Path) -> FccClient {
+        let config = DownloadConfig::with_cache_dir(cache.to_path_buf())
+            .with_base_url(server.uri())
+            .with_timeout(std::time::Duration::from_secs(10));
+        FccClient::new(config).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_run_update_fresh_db_applies_weekly_and_dailies() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        // Weekly published Sunday 2026-01-18; one Monday daily one day later.
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jan 18 12:01:25 EST 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_mon.zip",
+            build_fixture_zip("l_amat", "Mon Jan 19 12:01:25 EST 2026"),
+        )
+        .await;
+
+        let result = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+        match result {
+            UpdateResult::Updated { dailies, weekly } => {
+                assert!(weekly, "weekly should be applied on a fresh DB");
+                assert_eq!(dailies, 1, "exactly the Monday daily should apply");
+            }
+            other => panic!("expected Updated, got {:?}", DebugResult(&other)),
+        }
+
+        // Metadata reflects the weekly snapshot and the single applied patch.
+        assert_eq!(
+            db.get_last_weekly_date("HA").unwrap(),
+            NaiveDate::from_ymd_opt(2026, 1, 18)
+        );
+        let patches = db.get_applied_patches("HA").unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(
+            patches[0].patch_date,
+            NaiveDate::from_ymd_opt(2026, 1, 19).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_update_up_to_date_returns_uptodate() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        // Record an existing weekly far in the future so no daily is newer.
+        let weekly = NaiveDate::from_ymd_opt(2030, 6, 7).unwrap(); // a Friday
+        db.set_last_weekly_date("HA", weekly).unwrap();
+
+        // Serve dailies whose canonical dates predate the weekly, so the chain
+        // builder gates them all out.
+        mount_zip(
+            &server,
+            "/daily/l_am_mon.zip",
+            build_fixture_zip("l_amat", "Mon Jan 19 12:01:25 EST 2026"),
+        )
+        .await;
+
+        let result = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(result, UpdateResult::UpToDate));
+    }
+
+    #[tokio::test]
+    async fn test_run_update_check_only_reports_available_count() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        // Existing weekly on Sunday; a newer Monday daily is available.
+        let weekly = NaiveDate::from_ymd_opt(2026, 1, 18).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        mount_zip(
+            &server,
+            "/daily/l_am_mon.zip",
+            build_fixture_zip("l_amat", "Mon Jan 19 12:01:25 EST 2026"),
+        )
+        .await;
+
+        let result = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            false,
+            true, // check_only
+        )
+        .await
+        .unwrap();
+
+        match result {
+            UpdateResult::CheckOnly { available } => assert_eq!(available, 1),
+            other => panic!("expected CheckOnly, got {:?}", DebugResult(&other)),
+        }
+
+        // Check mode must not mutate patch state.
+        assert!(db.get_applied_patches("HA").unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_run_update_check_only_fresh_db_reports_weekly() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        // No weekly recorded and check_only: a weekly import is "available".
+        let result = run_update(&db, &client, "HA", &ImportMode::Minimal, false, false, true)
+            .await
+            .unwrap();
+
+        match result {
+            UpdateResult::CheckOnly { available } => assert_eq!(available, 1),
+            other => panic!("expected CheckOnly, got {:?}", DebugResult(&other)),
+        }
+        // Nothing imported.
+        assert!(db.get_last_weekly_date("HA").unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_run_update_daily_only_no_newer_dailies_is_uptodate() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        // daily_only with no weekly in DB: weekly_date defaults to today, and no
+        // served daily is newer than today, so the chain is empty.
+        mount_zip(
+            &server,
+            "/daily/l_am_mon.zip",
+            build_fixture_zip("l_amat", "Mon Jan 19 12:01:25 EST 2026"),
+        )
+        .await;
+
+        let result = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            true, // daily_only
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(result, UpdateResult::UpToDate));
+        // daily_only must not perform a weekly import.
+        assert!(db.get_last_weekly_date("HA").unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_run_update_broken_daily_chain_falls_back_to_weekly() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        // Existing weekly on Sunday 2026-01-18. The only available daily is for
+        // Thursday 2026-01-22, leaving a multi-day gap (Mon/Tue/Wed missing),
+        // which the chain builder reports as broken and falls back to weekly.
+        let weekly = NaiveDate::from_ymd_opt(2026, 1, 18).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+
+        mount_zip(
+            &server,
+            "/daily/l_am_thu.zip",
+            build_fixture_zip("l_amat", "Thu Jan 22 12:01:25 EST 2026"),
+        )
+        .await;
+        // Fresh weekly served for the fallback import.
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jan 25 12:01:25 EST 2026"),
+        )
+        .await;
+
+        let result = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+        match result {
+            UpdateResult::Updated { weekly, .. } => {
+                assert!(weekly, "fallback should perform a weekly import");
+            }
+            other => panic!("expected Updated, got {:?}", DebugResult(&other)),
+        }
+
+        // The fresh weekly date replaced the old one, and patches were cleared.
+        assert_eq!(
+            db.get_last_weekly_date("HA").unwrap(),
+            NaiveDate::from_ymd_opt(2026, 1, 25)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_update_broken_chain_check_only_reports_one() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 1, 18).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        mount_zip(
+            &server,
+            "/daily/l_am_thu.zip",
+            build_fixture_zip("l_amat", "Thu Jan 22 12:01:25 EST 2026"),
+        )
+        .await;
+
+        let result = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            false,
+            true, // check_only
+        )
+        .await
+        .unwrap();
+
+        match result {
+            UpdateResult::CheckOnly { available } => assert_eq!(available, 1),
+            other => panic!("expected CheckOnly, got {:?}", DebugResult(&other)),
+        }
+        // Old weekly untouched in check mode.
+        assert_eq!(db.get_last_weekly_date("HA").unwrap(), Some(weekly));
+    }
+
+    #[tokio::test]
+    async fn test_extract_canonical_date_round_trip() {
+        let tmp = TempDir::new().unwrap();
+        let zip_path = tmp.path().join("l_amat.zip");
+        let body = build_fixture_zip("l_amat", "Sun Jan 18 12:01:25 EST 2026");
+        fs::write(&zip_path, body).unwrap();
+
+        let date = extract_canonical_date(&zip_path).unwrap();
+        assert_eq!(date, NaiveDate::from_ymd_opt(2026, 1, 18));
+    }
+
+    #[tokio::test]
+    async fn test_extract_canonical_date_missing_counts_is_none() {
+        let tmp = TempDir::new().unwrap();
+        let zip_path = tmp.path().join("no_counts.zip");
+        let mut buf = Vec::new();
+        {
+            let cursor = std::io::Cursor::new(&mut buf);
+            let mut zip = ZipWriter::new(cursor);
+            let opts =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            zip.start_file("HD.dat", opts).unwrap();
+            zip.write_all(b"HD|1|||TEST|A|HA|\n").unwrap();
+            zip.finish().unwrap();
+        }
+        fs::write(&zip_path, buf).unwrap();
+
+        assert_eq!(extract_canonical_date(&zip_path).unwrap(), None);
+    }
+
+    /// Wrapper that makes the private `UpdateResult` printable in panic messages.
+    struct DebugResult<'a>(&'a UpdateResult);
+    impl std::fmt::Debug for DebugResult<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self.0 {
+                UpdateResult::UpToDate => write!(f, "UpToDate"),
+                UpdateResult::Updated { dailies, weekly } => {
+                    write!(f, "Updated {{ dailies: {}, weekly: {} }}", dailies, weekly)
+                }
+                UpdateResult::CheckOnly { available } => {
+                    write!(f, "CheckOnly {{ available: {} }}", available)
+                }
+            }
+        }
+    }
 }

--- a/crates/uls-cli/src/config.rs
+++ b/crates/uls-cli/src/config.rs
@@ -23,3 +23,41 @@ pub fn default_cache_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(".cache"))
         .join("uls")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `ULS_DB_PATH` is process-global, so the fallback and env-override
+    /// branches run in one test to avoid cross-test interference.
+    #[test]
+    fn test_default_db_path_env_branches() {
+        // Save and clear so we observe the fallback first.
+        let saved = std::env::var("ULS_DB_PATH").ok();
+        std::env::remove_var("ULS_DB_PATH");
+
+        let fallback = default_db_path();
+        assert!(
+            fallback.ends_with("uls/uls.db") || fallback.ends_with("uls\\uls.db"),
+            "fallback should end with uls/uls.db, got {}",
+            fallback.display()
+        );
+
+        // Explicit env var takes precedence verbatim.
+        std::env::set_var("ULS_DB_PATH", "/tmp/custom/explicit.db");
+        assert_eq!(default_db_path(), PathBuf::from("/tmp/custom/explicit.db"));
+
+        // Restore prior state.
+        match saved {
+            Some(v) => std::env::set_var("ULS_DB_PATH", v),
+            None => std::env::remove_var("ULS_DB_PATH"),
+        }
+    }
+
+    #[test]
+    fn test_default_cache_path_ends_with_uls() {
+        let path = default_cache_path();
+        let last = path.file_name().and_then(|s| s.to_str());
+        assert_eq!(last, Some("uls"));
+    }
+}

--- a/crates/uls-cli/src/staleness.rs
+++ b/crates/uls-cli/src/staleness.rs
@@ -134,3 +134,37 @@ pub fn warn_if_stale_after_query(service_code: &str, options: &StalenessOptions)
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_cli_maps_flags() {
+        let opts = StalenessOptions::from_cli(7, false, false);
+        assert_eq!(opts.threshold_days, 7);
+        assert!(opts.warn_enabled);
+        assert!(!opts.auto_update);
+    }
+
+    #[test]
+    fn test_from_cli_no_warning_inverts_flag() {
+        let opts = StalenessOptions::from_cli(3, true, false);
+        assert!(!opts.warn_enabled);
+    }
+
+    #[test]
+    fn test_from_cli_auto_update() {
+        let opts = StalenessOptions::from_cli(1, false, true);
+        assert_eq!(opts.threshold_days, 1);
+        assert!(opts.auto_update);
+    }
+
+    #[test]
+    fn test_default_options() {
+        let opts = StalenessOptions::default_options();
+        assert_eq!(opts.threshold_days, DEFAULT_STALE_THRESHOLD_DAYS);
+        assert!(opts.warn_enabled);
+        assert!(!opts.auto_update);
+    }
+}

--- a/crates/uls-cli/tests/cli_integration.rs
+++ b/crates/uls-cli/tests/cli_integration.rs
@@ -96,6 +96,47 @@ fn get_first_callsign(service: &str) -> String {
     panic!("No callsign found in fixture");
 }
 
+/// Get the first non-empty FRN from fixture EN.dat (column 23, 1-indexed).
+fn get_first_frn(service: &str) -> String {
+    use std::io::{BufRead, BufReader};
+
+    let en_path = fixture_path().join(service).join("EN.dat");
+    let file = File::open(&en_path).expect("EN.dat should exist");
+    let reader = BufReader::new(file);
+
+    for line in reader.lines().map_while(Result::ok) {
+        let fields: Vec<&str> = line.split('|').collect();
+        if fields.len() > 22
+            && fields[22].len() == 10
+            && fields[22].chars().all(|c| c.is_ascii_digit())
+        {
+            return fields[22].to_string();
+        }
+    }
+    panic!("No FRN found in fixture");
+}
+
+/// Get the call sign (column 5) from the same EN.dat row that `get_first_frn`
+/// selects, so an FRN lookup can be checked against its expected call sign.
+fn get_callsign_for_first_frn(service: &str) -> String {
+    use std::io::{BufRead, BufReader};
+
+    let en_path = fixture_path().join(service).join("EN.dat");
+    let file = File::open(&en_path).expect("EN.dat should exist");
+    let reader = BufReader::new(file);
+
+    for line in reader.lines().map_while(Result::ok) {
+        let fields: Vec<&str> = line.split('|').collect();
+        if fields.len() > 22
+            && fields[22].len() == 10
+            && fields[22].chars().all(|c| c.is_ascii_digit())
+        {
+            return fields[4].to_string();
+        }
+    }
+    panic!("No FRN found in fixture");
+}
+
 // =============================================================================
 // Help and version tests (no database needed)
 // =============================================================================
@@ -512,4 +553,277 @@ fn test_db_help() {
         .stdout(predicate::str::contains("init"))
         .stdout(predicate::str::contains("info"))
         .stdout(predicate::str::contains("vacuum"));
+}
+
+// =============================================================================
+// Output format branches (search / lookup)
+// =============================================================================
+
+#[test]
+fn test_search_yaml_output() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+
+    // YAML output lists results as a sequence with field keys.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["search", "--name", "*", "--limit", "2", "--format", "yaml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("call_sign:"));
+}
+
+#[test]
+fn test_search_custom_fields_csv() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+
+    // --fields with csv format emits exactly the selected header columns.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args([
+            "search",
+            "--name",
+            "*",
+            "--limit",
+            "3",
+            "--format",
+            "csv",
+            "--fields",
+            "call_sign,state",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("call_sign,state"));
+}
+
+#[test]
+fn test_search_custom_fields_table() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+
+    // --fields with the default table format renders a header row plus a
+    // result count footer.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args([
+            "search",
+            "--name",
+            "*",
+            "--limit",
+            "3",
+            "--fields",
+            "call_sign,city,state",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("call_sign"))
+        .stdout(predicate::str::contains("result(s)"));
+}
+
+#[test]
+fn test_search_no_filter_errors() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+
+    // A bare search with no filters exits non-zero with usage guidance.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["search"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "At least one search filter is required",
+        ));
+}
+
+#[test]
+fn test_search_state_filter() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+
+    // A state not present in the fixtures yields no results and a non-zero exit.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["search", "--state", "ZZ"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No results"));
+}
+
+#[test]
+fn test_lookup_yaml_output() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+    let callsign = get_first_callsign("l_amat");
+
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["lookup", &callsign, "--format", "yaml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("call_sign:"))
+        .stdout(predicate::str::contains(&callsign));
+}
+
+#[test]
+fn test_lookup_all_services_flag() {
+    use uls_db::{Database, DatabaseConfig};
+
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat", "l_gmrs"]);
+    let ha_call = get_first_callsign("l_amat");
+    let za_call = get_first_callsign("l_gmrs");
+
+    // Give an amateur and a GMRS license the same FRN so the --all cross-service
+    // FRN expansion links them.
+    {
+        let db = Database::with_config(DatabaseConfig::with_path(&db_path)).unwrap();
+        let conn = db.conn().unwrap();
+        for call in [&ha_call, &za_call] {
+            conn.execute(
+                "UPDATE entities SET frn = ?1 WHERE call_sign = ?2",
+                ("0000099999", call.as_str()),
+            )
+            .unwrap();
+        }
+    }
+
+    // Plain lookup returns only the requested amateur callsign.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["lookup", &ha_call])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&ha_call))
+        .stdout(predicate::str::contains(&za_call).not());
+
+    // --all expands by the shared FRN and surfaces the GMRS callsign too.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["lookup", &ha_call, "--all"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&ha_call))
+        .stdout(predicate::str::contains(&za_call));
+}
+
+// =============================================================================
+// FRN lookup success path
+// =============================================================================
+
+#[test]
+fn test_frn_lookup_success() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+    let frn = get_first_frn("l_amat");
+    let callsign = get_callsign_for_first_frn("l_amat");
+
+    // The FRN is not a table column, so the lookup is confirmed by the call sign
+    // of the resolved license appearing in the rendered table.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["frn", &frn])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&callsign))
+        .stdout(predicate::str::contains("result(s)"));
+}
+
+#[test]
+fn test_frn_lookup_json_output() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+    let frn = get_first_frn("l_amat");
+
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["frn", &frn, "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("["));
+}
+
+// =============================================================================
+// Stats and db info format branches
+// =============================================================================
+
+#[test]
+fn test_stats_json_output() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["stats", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("{"))
+        .stdout(predicate::str::contains("total_licenses"));
+}
+
+#[test]
+fn test_stats_default_text_output() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["stats"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Database Statistics"))
+        .stdout(predicate::str::contains("Active licenses"))
+        .stdout(predicate::str::contains("Schema version"));
+}
+
+#[test]
+fn test_db_info_default_text_fields() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["db", "info"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Schema version"))
+        .stdout(predicate::str::contains("Total licenses"));
+}
+
+// =============================================================================
+// Staleness warning behavior
+// =============================================================================
+
+#[test]
+fn test_staleness_warning_emitted() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+    let callsign = get_first_callsign("l_amat");
+
+    // Fixture imports leave last_updated unset, so data reads as stale and a
+    // warning is printed to stderr after the query result. The HA service maps
+    // to the "amateur" label in the suggested command.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["lookup", &callsign])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("uls update --service amateur"));
+}
+
+#[test]
+fn test_staleness_warning_suppressed() {
+    let (_temp_dir, db_path) = setup_test_db(&["l_amat"]);
+    let callsign = get_first_callsign("l_amat");
+
+    // --no-stale-warning suppresses the freshness notice on stderr.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .env("ULS_DB_PATH", &db_path)
+        .args(["--no-stale-warning", "lookup", &callsign])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("uls update").not());
 }

--- a/crates/uls-core/src/codes.rs
+++ b/crates/uls-core/src/codes.rs
@@ -2375,4 +2375,131 @@ mod tests {
         assert_eq!(upper, lower);
         assert_eq!(lower, mixed);
     }
+
+    #[test]
+    fn test_radio_service_u8_roundtrip_all() {
+        // Every value that decodes to a variant must re-encode to the same byte,
+        // and that variant's string form must FromStr back to the same variant.
+        let mut decoded = 0u8;
+        for v in 0u8..=255 {
+            match RadioService::from_u8(v) {
+                Some(service) => {
+                    decoded += 1;
+                    assert_eq!(service.to_u8(), v, "to_u8/from_u8 mismatch for {v}");
+                    assert!(!service.as_str().is_empty());
+                    assert!(!service.description().is_empty());
+                    let parsed: RadioService = service.as_str().parse().unwrap();
+                    assert_eq!(parsed, service);
+                }
+                None => assert!(v > 141, "value {v} should decode to a RadioService"),
+            }
+        }
+        // All 142 variants (0..=141) decode; nothing above does.
+        assert_eq!(decoded, 142);
+    }
+
+    #[test]
+    fn test_radio_service_u8_endpoints() {
+        assert_eq!(RadioService::from_u8(0), Some(RadioService::AA));
+        assert_eq!(RadioService::from_u8(141), Some(RadioService::ZV));
+        assert_eq!(RadioService::AA.to_u8(), 0);
+        assert_eq!(RadioService::ZV.to_u8(), 141);
+        assert_eq!(RadioService::from_u8(142), None);
+        assert_eq!(RadioService::from_u8(255), None);
+    }
+
+    #[test]
+    fn test_license_status_u8_roundtrip_all() {
+        let mut decoded = 0u8;
+        for v in 0u8..=255 {
+            match LicenseStatus::from_u8(v) {
+                Some(status) => {
+                    decoded += 1;
+                    assert_eq!(status.to_u8(), v, "to_u8/from_u8 mismatch for {v}");
+                    assert!(!status.as_str().is_empty());
+                    let parsed: LicenseStatus = status.as_str().parse().unwrap();
+                    assert_eq!(parsed, status);
+                }
+                None => assert!(v > 6, "value {v} should decode to a LicenseStatus"),
+            }
+        }
+        assert_eq!(decoded, 7);
+        assert_eq!(LicenseStatus::from_u8(7), None);
+        assert_eq!(LicenseStatus::from_u8(255), None);
+    }
+
+    #[test]
+    fn test_license_status_u8_specific() {
+        assert_eq!(LicenseStatus::Active.to_u8(), 0);
+        assert_eq!(LicenseStatus::Cancelled.to_u8(), 1);
+        assert_eq!(LicenseStatus::Expired.to_u8(), 2);
+        assert_eq!(LicenseStatus::PendingLegalStatus.to_u8(), 3);
+        assert_eq!(LicenseStatus::ParentStationCancelled.to_u8(), 4);
+        assert_eq!(LicenseStatus::Terminated.to_u8(), 5);
+        assert_eq!(LicenseStatus::TermPending.to_u8(), 6);
+    }
+
+    #[test]
+    fn test_operator_class_u8_roundtrip_all() {
+        let mut decoded = 0u8;
+        for v in 0u8..=255 {
+            match OperatorClass::from_u8(v) {
+                Some(class) => {
+                    decoded += 1;
+                    assert_eq!(class.to_u8(), v, "to_u8/from_u8 mismatch for {v}");
+                    assert!(!class.as_str().is_empty());
+                    assert!(!class.description().is_empty());
+                    let parsed: OperatorClass = class.as_str().parse().unwrap();
+                    assert_eq!(parsed, class);
+                }
+                None => assert!(v > 5, "value {v} should decode to an OperatorClass"),
+            }
+        }
+        assert_eq!(decoded, 6);
+        assert_eq!(OperatorClass::from_u8(6), None);
+        assert_eq!(OperatorClass::from_u8(255), None);
+    }
+
+    #[test]
+    fn test_operator_class_u8_specific() {
+        assert_eq!(OperatorClass::Advanced.to_u8(), 0);
+        assert_eq!(OperatorClass::Extra.to_u8(), 1);
+        assert_eq!(OperatorClass::General.to_u8(), 2);
+        assert_eq!(OperatorClass::Novice.to_u8(), 3);
+        assert_eq!(OperatorClass::TechnicianPlus.to_u8(), 4);
+        assert_eq!(OperatorClass::Technician.to_u8(), 5);
+    }
+
+    #[test]
+    fn test_entity_type_u8_roundtrip_all() {
+        let mut decoded = 0u8;
+        for v in 0u8..=255 {
+            match EntityType::from_u8(v) {
+                Some(entity) => {
+                    decoded += 1;
+                    assert_eq!(entity.to_u8(), v, "to_u8/from_u8 mismatch for {v}");
+                    assert!(!entity.as_str().is_empty());
+                    let parsed: EntityType = entity.as_str().parse().unwrap();
+                    assert_eq!(parsed, entity);
+                }
+                None => assert!(v > 8, "value {v} should decode to an EntityType"),
+            }
+        }
+        assert_eq!(decoded, 9);
+        assert_eq!(EntityType::from_u8(9), None);
+        assert_eq!(EntityType::from_u8(255), None);
+    }
+
+    #[test]
+    fn test_entity_type_u8_specific() {
+        assert_eq!(EntityType::TransfereeContact.to_u8(), 0);
+        assert_eq!(EntityType::LicenseeContact.to_u8(), 1);
+        assert_eq!(EntityType::AssignorContact.to_u8(), 2);
+        assert_eq!(EntityType::LesseeContact.to_u8(), 3);
+        assert_eq!(EntityType::Transferee.to_u8(), 4);
+        assert_eq!(EntityType::Licensee.to_u8(), 5);
+        assert_eq!(EntityType::Owner.to_u8(), 6);
+        assert_eq!(EntityType::Assignor.to_u8(), 7);
+        assert_eq!(EntityType::Lessee.to_u8(), 8);
+    }
 }

--- a/crates/uls-core/src/records.rs
+++ b/crates/uls-core/src/records.rs
@@ -266,4 +266,98 @@ mod tests {
         assert_eq!(special_condition_record().call_sign(), Some("W8TEST"));
         assert_eq!(raw_record().call_sign(), None);
     }
+
+    fn application_detail_record() -> UlsRecord {
+        UlsRecord::ApplicationDetail(ApplicationDetailRecord::from_fields(&[
+            "AD", "100009", "", "", "NE",
+        ]))
+    }
+
+    fn antenna_record() -> UlsRecord {
+        UlsRecord::Antenna(AntennaRecord::from_fields(&[
+            "AN", "100010", "", "", "WANT01",
+        ]))
+    }
+
+    fn emission_record() -> UlsRecord {
+        UlsRecord::Emission(EmissionRecord::from_fields(&[
+            "EM", "100011", "", "", "WEMI01",
+        ]))
+    }
+
+    fn freeform_condition_record() -> UlsRecord {
+        UlsRecord::FreeformCondition(FreeformConditionRecord::from_fields(&[
+            "SF", "100012", "", "", "WSFC01",
+        ]))
+    }
+
+    fn vanity_callsign_record() -> UlsRecord {
+        UlsRecord::VanityCallSign(VanityCallSignRecord::from_fields(&[
+            "VC", "100013", "", "", "1", "W1AW",
+        ]))
+    }
+
+    fn aircraft_record() -> UlsRecord {
+        UlsRecord::Aircraft(AircraftRecord::from_fields(&[
+            "AC", "100014", "", "", "WACR01",
+        ]))
+    }
+
+    fn ship_record() -> UlsRecord {
+        UlsRecord::Ship(ShipRecord::from_fields(&["SH", "100015", "", "", "WSHP01"]))
+    }
+
+    #[test]
+    fn test_record_type_dispatch_remaining_variants() {
+        assert_eq!(application_detail_record().record_type(), RecordType::AD);
+        assert_eq!(antenna_record().record_type(), RecordType::AN);
+        assert_eq!(emission_record().record_type(), RecordType::EM);
+        assert_eq!(freeform_condition_record().record_type(), RecordType::SF);
+        assert_eq!(vanity_callsign_record().record_type(), RecordType::VC);
+        assert_eq!(aircraft_record().record_type(), RecordType::AC);
+        assert_eq!(ship_record().record_type(), RecordType::SH);
+    }
+
+    #[test]
+    fn test_unique_system_identifier_dispatch_remaining_variants() {
+        assert_eq!(
+            application_detail_record().unique_system_identifier(),
+            Some(100009)
+        );
+        assert_eq!(antenna_record().unique_system_identifier(), Some(100010));
+        assert_eq!(emission_record().unique_system_identifier(), Some(100011));
+        // FreeformCondition stores an Option<i64> and forwards it directly.
+        assert_eq!(
+            freeform_condition_record().unique_system_identifier(),
+            Some(100012)
+        );
+        assert_eq!(
+            vanity_callsign_record().unique_system_identifier(),
+            Some(100013)
+        );
+        assert_eq!(aircraft_record().unique_system_identifier(), Some(100014));
+        // Ship stores an Option<i64> and forwards it directly.
+        assert_eq!(ship_record().unique_system_identifier(), Some(100015));
+    }
+
+    #[test]
+    fn test_option_usi_variants_return_none_when_missing() {
+        // FreeformCondition and Ship carry Option<i64>; a missing id forwards None.
+        let sf = UlsRecord::FreeformCondition(FreeformConditionRecord::from_fields(&["SF"]));
+        assert_eq!(sf.unique_system_identifier(), None);
+        let sh = UlsRecord::Ship(ShipRecord::from_fields(&["SH"]));
+        assert_eq!(sh.unique_system_identifier(), None);
+    }
+
+    #[test]
+    fn test_call_sign_dispatch_remaining_variants() {
+        assert_eq!(antenna_record().call_sign(), Some("WANT01"));
+        assert_eq!(emission_record().call_sign(), Some("WEMI01"));
+        assert_eq!(freeform_condition_record().call_sign(), Some("WSFC01"));
+        assert_eq!(aircraft_record().call_sign(), Some("WACR01"));
+        assert_eq!(ship_record().call_sign(), Some("WSHP01"));
+        // ApplicationDetail and VanityCallSign expose no call sign.
+        assert_eq!(application_detail_record().call_sign(), None);
+        assert_eq!(vanity_callsign_record().call_sign(), None);
+    }
 }

--- a/crates/uls-core/src/records/amateur.rs
+++ b/crates/uls-core/src/records/amateur.rs
@@ -110,4 +110,38 @@ mod tests {
         record.trustee_callsign = Some("N1MM".to_string());
         assert!(record.is_club());
     }
+
+    #[test]
+    fn test_is_club_trustee_callsign_only() {
+        let mut record = AmateurRecord::from_fields(&["AM", "123"]);
+        record.trustee_callsign = Some("N1MM".to_string());
+        assert!(record.is_club());
+    }
+
+    #[test]
+    fn test_is_club_false_when_no_trustee() {
+        let record = AmateurRecord::from_fields(&["AM", "123"]);
+        assert!(!record.is_club());
+    }
+
+    #[rstest::rstest]
+    #[case('A', "Advanced")]
+    #[case('E', "Amateur Extra")]
+    #[case('G', "General")]
+    #[case('N', "Novice")]
+    #[case('P', "Technician Plus")]
+    #[case('T', "Technician")]
+    fn test_operator_class_description_all(#[case] code: char, #[case] expected: &str) {
+        let mut record = AmateurRecord::from_fields(&["AM", "123"]);
+        record.operator_class = Some(code);
+        assert_eq!(record.operator_class_description(), Some(expected));
+    }
+
+    #[test]
+    fn test_operator_class_description_unknown_and_missing() {
+        let mut record = AmateurRecord::from_fields(&["AM", "123"]);
+        assert_eq!(record.operator_class_description(), None);
+        record.operator_class = Some('Z');
+        assert_eq!(record.operator_class_description(), None);
+    }
 }

--- a/crates/uls-core/src/records/common.rs
+++ b/crates/uls-core/src/records/common.rs
@@ -213,4 +213,81 @@ mod tests {
         assert_eq!(parse_opt_f64("-0.5"), Some(-0.5));
         assert_eq!(parse_opt_f64(""), None);
     }
+
+    #[test]
+    fn test_coordinates_decimal_southern_hemisphere() {
+        // 'S' latitude and 'E' longitude: latitude negates, longitude stays positive.
+        let coords = Coordinates {
+            lat_degrees: Some(33),
+            lat_minutes: Some(52),
+            lat_seconds: Some(0.0),
+            lat_direction: Some('S'),
+            long_degrees: Some(151),
+            long_minutes: Some(12),
+            long_seconds: Some(0.0),
+            long_direction: Some('E'),
+        };
+        let (lat, long) = coords.to_decimal().unwrap();
+        assert!((lat - (-33.866_67)).abs() < 0.001);
+        assert!((long - 151.2).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_coordinates_decimal_default_directions() {
+        // Missing minutes/seconds/directions default to 0 and N/W respectively.
+        let coords = Coordinates {
+            lat_degrees: Some(40),
+            lat_minutes: None,
+            lat_seconds: None,
+            lat_direction: None,
+            long_degrees: Some(74),
+            long_minutes: None,
+            long_seconds: None,
+            long_direction: None,
+        };
+        let (lat, long) = coords.to_decimal().unwrap();
+        assert!((lat - 40.0).abs() < 0.001);
+        assert!((long - (-74.0)).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_coordinates_decimal_none_without_longitude_degrees() {
+        // Latitude present but longitude degrees missing yields None.
+        let coords = Coordinates {
+            lat_degrees: Some(40),
+            long_degrees: None,
+            ..Coordinates::empty()
+        };
+        assert_eq!(coords.to_decimal(), None);
+    }
+
+    #[test]
+    fn test_coordinates_default_equals_empty() {
+        assert_eq!(Coordinates::default(), Coordinates::empty());
+    }
+
+    #[test]
+    fn test_parse_opt_char() {
+        assert_eq!(parse_opt_char("A"), Some('A'));
+        assert_eq!(parse_opt_char("  Y  "), Some('Y'));
+        // Only the first character is taken.
+        assert_eq!(parse_opt_char("XYZ"), Some('X'));
+        assert_eq!(parse_opt_char(""), None);
+        assert_eq!(parse_opt_char("   "), None);
+    }
+
+    #[test]
+    fn test_parse_opt_i64() {
+        assert_eq!(parse_opt_i64("9000000000"), Some(9_000_000_000));
+        assert_eq!(parse_opt_i64("-42"), Some(-42));
+        assert_eq!(parse_opt_i64(""), None);
+        assert_eq!(parse_opt_i64("abc"), None);
+    }
+
+    #[test]
+    fn test_parse_i64_or_default() {
+        assert_eq!(parse_i64_or_default("123456"), 123456);
+        assert_eq!(parse_i64_or_default(""), 0);
+        assert_eq!(parse_i64_or_default("not-a-number"), 0);
+    }
 }

--- a/crates/uls-core/src/records/entity.rs
+++ b/crates/uls-core/src/records/entity.rs
@@ -174,4 +174,60 @@ mod tests {
         record.entity_name = Some("ACME Corp".to_string());
         assert_eq!(record.full_name(), "ACME Corp");
     }
+
+    #[test]
+    fn test_full_name_with_mi_and_suffix() {
+        let mut record = EntityRecord::from_fields(&["EN", "123"]);
+        record.first_name = Some("Hiram".to_string());
+        record.mi = Some('P');
+        record.last_name = Some("Maxim".to_string());
+        record.suffix = Some("Jr".to_string());
+        assert_eq!(record.full_name(), "Hiram P Maxim Jr");
+    }
+
+    #[test]
+    fn test_full_name_ignores_empty_entity_name() {
+        let mut record = EntityRecord::from_fields(&["EN", "123"]);
+        record.entity_name = Some(String::new());
+        record.first_name = Some("Jane".to_string());
+        record.last_name = Some("Roe".to_string());
+        assert_eq!(record.full_name(), "Jane Roe");
+    }
+
+    #[test]
+    fn test_full_name_empty_when_no_parts() {
+        let record = EntityRecord::from_fields(&["EN", "123"]);
+        assert_eq!(record.full_name(), "");
+    }
+
+    #[test]
+    fn test_full_address_street_city_state_zip() {
+        let mut record = EntityRecord::from_fields(&["EN", "123"]);
+        record.street_address = Some("225 Main St".to_string());
+        record.city = Some("Newington".to_string());
+        record.state = Some("CT".to_string());
+        record.zip_code = Some("06111".to_string());
+        assert_eq!(record.full_address(), "225 Main St, Newington, CT 06111");
+    }
+
+    #[test]
+    fn test_full_address_street_only() {
+        let mut record = EntityRecord::from_fields(&["EN", "123"]);
+        record.street_address = Some("1 Radio Way".to_string());
+        assert_eq!(record.full_address(), "1 Radio Way");
+    }
+
+    #[test]
+    fn test_full_address_city_without_state_or_zip_is_trimmed() {
+        let mut record = EntityRecord::from_fields(&["EN", "123"]);
+        record.city = Some("Newington".to_string());
+        // No state or zip: the trailing separators are trimmed off.
+        assert_eq!(record.full_address(), "Newington,");
+    }
+
+    #[test]
+    fn test_full_address_empty_when_no_parts() {
+        let record = EntityRecord::from_fields(&["EN", "123"]);
+        assert_eq!(record.full_address(), "");
+    }
 }

--- a/crates/uls-core/src/records/frequency.rs
+++ b/crates/uls-core/src/records/frequency.rs
@@ -126,4 +126,20 @@ mod tests {
         assert_eq!(record.unique_system_identifier, 123456789);
         assert!((record.frequency_assigned.unwrap() - 146.94).abs() < 0.001);
     }
+
+    #[test]
+    fn test_frequency_mhz_and_khz() {
+        let mut record = FrequencyRecord::from_fields(&["FR", "1"]);
+        record.frequency_assigned = Some(146.94);
+        assert_eq!(record.frequency_mhz(), Some(146.94));
+        assert!((record.frequency_khz().unwrap() - 146_940.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_frequency_mhz_and_khz_none_when_unassigned() {
+        let record = FrequencyRecord::from_fields(&["FR", "1"]);
+        assert_eq!(record.frequency_assigned, None);
+        assert_eq!(record.frequency_mhz(), None);
+        assert_eq!(record.frequency_khz(), None);
+    }
 }

--- a/crates/uls-core/src/records/header.rs
+++ b/crates/uls-core/src/records/header.rs
@@ -230,4 +230,26 @@ mod tests {
         assert_eq!(record.call_sign, None);
         assert!(!record.is_active());
     }
+
+    #[test]
+    fn test_header_is_expired() {
+        let mut record = HeaderRecord::from_fields(&["HD", "1"]);
+        record.license_status = Some('E');
+        assert!(record.is_expired());
+        assert!(!record.is_active());
+    }
+
+    #[test]
+    fn test_header_is_expired_false_for_active() {
+        let mut record = HeaderRecord::from_fields(&["HD", "1"]);
+        record.license_status = Some('A');
+        assert!(!record.is_expired());
+        assert!(record.is_active());
+    }
+
+    #[test]
+    fn test_header_is_expired_false_when_status_missing() {
+        let record = HeaderRecord::from_fields(&["HD", "1"]);
+        assert!(!record.is_expired());
+    }
 }

--- a/crates/uls-db/src/bulk_inserter.rs
+++ b/crates/uls-db/src/bulk_inserter.rs
@@ -616,6 +616,133 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_amateur_stores_optional_fields() {
+        let conn = setup_db();
+        let mut inserter = BulkInserter::new(&conn).unwrap();
+        insert_parent_header(&mut inserter);
+
+        inserter
+            .insert(&UlsRecord::Amateur(create_amateur()))
+            .unwrap();
+
+        // region_code is parsed as an integer; group_code as text; the amateur
+        // fixture uses class E, group D, region 6.
+        let (region, group): (Option<i64>, Option<String>) = conn
+            .query_row(
+                "SELECT region_code, group_code FROM amateur_operators WHERE call_sign = ?",
+                [TEST_CALLSIGN],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(region, Some(6));
+        assert_eq!(group, Some("D".to_string()));
+
+        // operator_class is encoded as an integer code, not the raw char 'E';
+        // the code decodes back to the Extra class the fixture used.
+        let class_code: Option<i64> = conn
+            .query_row(
+                "SELECT operator_class FROM amateur_operators WHERE call_sign = ?",
+                [TEST_CALLSIGN],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let class =
+            OperatorClass::from_u8(class_code.expect("operator_class should be encoded") as u8);
+        assert_eq!(class, Some(OperatorClass::Extra));
+    }
+
+    #[test]
+    fn test_insert_entity_stores_address_and_frn() {
+        let conn = setup_db();
+        let mut inserter = BulkInserter::new(&conn).unwrap();
+        insert_parent_header(&mut inserter);
+
+        inserter
+            .insert(&UlsRecord::Entity(create_entity()))
+            .unwrap();
+
+        let field = |column: &str| -> Option<String> {
+            conn.query_row(
+                &format!("SELECT {column} FROM entities WHERE call_sign = ?"),
+                [TEST_CALLSIGN],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(field("city"), Some("ANYTOWN".to_string()));
+        assert_eq!(field("state"), Some("CA".to_string()));
+        assert_eq!(field("zip_code"), Some("90210".to_string()));
+        assert_eq!(field("frn"), Some("0001234567".to_string()));
+        assert_eq!(field("email"), Some("test@example.com".to_string()));
+    }
+
+    #[test]
+    fn test_insert_header_encodes_status_and_service() {
+        let conn = setup_db();
+        let mut inserter = BulkInserter::new(&conn).unwrap();
+
+        inserter
+            .insert(&UlsRecord::Header(create_header()))
+            .unwrap();
+
+        // Status 'A' and service "HA" are stored as integer codes that decode
+        // back to the Active status and HA radio service the fixture used.
+        let (status, service): (Option<i64>, Option<i64>) = conn
+            .query_row(
+                "SELECT license_status, radio_service_code FROM licenses WHERE call_sign = ?",
+                [TEST_CALLSIGN],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        let status =
+            LicenseStatus::from_u8(status.expect("license_status should be encoded") as u8);
+        assert_eq!(status, Some(LicenseStatus::Active));
+        let service =
+            RadioService::from_u8(service.expect("radio_service_code should be encoded") as u8);
+        assert_eq!(service, Some(RadioService::HA));
+
+        // Dates are normalized to YYYY-MM-DD strings on the way in.
+        let grant: Option<String> = conn
+            .query_row(
+                "SELECT grant_date FROM licenses WHERE call_sign = ?",
+                [TEST_CALLSIGN],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(grant, Some("2020-01-15".to_string()));
+    }
+
+    #[test]
+    fn test_insert_entity_replace_updates_in_place() {
+        let conn = setup_db();
+        let mut inserter = BulkInserter::new(&conn).unwrap();
+        insert_parent_header(&mut inserter);
+
+        inserter
+            .insert(&UlsRecord::Entity(create_entity()))
+            .unwrap();
+
+        // A second entity with the same (usi, entity_type) replaces the first.
+        let mut updated = create_entity();
+        updated.city = Some("NEWCITY".to_string());
+        inserter.insert(&UlsRecord::Entity(updated)).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM entities", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let city: Option<String> = conn
+            .query_row(
+                "SELECT city FROM entities WHERE call_sign = ?",
+                [TEST_CALLSIGN],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(city, Some("NEWCITY".to_string()));
+    }
+
+    #[test]
     fn test_insert_replace_behavior() {
         let conn = setup_db();
         let mut inserter = BulkInserter::new(&conn).unwrap();

--- a/crates/uls-db/src/config.rs
+++ b/crates/uls-db/src/config.rs
@@ -126,4 +126,22 @@ mod tests {
         // 256MB * 1000 = 256000 pages, stored as negative
         assert_eq!(config.cache_size, -256000);
     }
+
+    #[test]
+    fn test_default_db_path_ends_with_uls_db() {
+        let path = default_db_path();
+        assert_eq!(path.file_name().and_then(|n| n.to_str()), Some("uls.db"));
+        assert_eq!(
+            path.parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str()),
+            Some("uls")
+        );
+    }
+
+    #[test]
+    fn test_default_config_path_is_uls_db() {
+        let path = DatabaseConfig::default().path;
+        assert_eq!(path.file_name().and_then(|n| n.to_str()), Some("uls.db"));
+    }
 }

--- a/crates/uls-db/src/freshness.rs
+++ b/crates/uls-db/src/freshness.rs
@@ -318,6 +318,102 @@ mod tests {
     }
 
     #[test]
+    fn test_freshness_unknown_constructor() {
+        let freshness = DataFreshness::unknown("ZA");
+        assert_eq!(freshness.service, "ZA");
+        assert!(freshness.is_stale);
+        assert!(freshness.last_updated.is_none());
+        assert!(freshness.age.is_none());
+        assert_eq!(freshness.age_display, "unknown");
+        assert!(freshness.last_weekly_date.is_none());
+        assert!(freshness.applied_patch_dates.is_empty());
+        assert!(freshness.missing_patch_dates.is_empty());
+    }
+
+    #[test]
+    fn test_age_days_none_when_unknown() {
+        let freshness = DataFreshness::unknown("HA");
+        assert_eq!(freshness.age_days(), None);
+    }
+
+    #[test]
+    fn test_needs_weekly_update_tracks_last_weekly_date() {
+        let mut freshness = DataFreshness::unknown("HA");
+        assert!(freshness.needs_weekly_update());
+
+        freshness.last_weekly_date = NaiveDate::from_ymd_opt(2026, 1, 5);
+        assert!(!freshness.needs_weekly_update());
+    }
+
+    #[test]
+    fn test_has_missing_patches() {
+        let mut freshness = DataFreshness::unknown("HA");
+        assert!(!freshness.has_missing_patches());
+
+        freshness.missing_patch_dates = vec![NaiveDate::from_ymd_opt(2026, 1, 6).unwrap()];
+        assert!(freshness.has_missing_patches());
+    }
+
+    #[test]
+    fn test_age_display_minutes_for_very_recent() {
+        let recent = Utc::now() - Duration::minutes(30);
+        let timestamp = recent.format("%Y-%m-%d %H:%M:%S UTC").to_string();
+        let freshness = DataFreshness::from_timestamp("HA", Some(&timestamp), 3);
+        assert!(freshness.age_display.ends_with('m'));
+        assert!(!freshness.age_display.contains('h'));
+        assert!(!freshness.is_stale);
+    }
+
+    #[test]
+    fn test_from_timestamp_rfc3339() {
+        let recent = Utc::now() - Duration::hours(2);
+        let timestamp = recent.to_rfc3339();
+        let freshness = DataFreshness::from_timestamp("HA", Some(&timestamp), 3);
+        assert!(freshness.last_updated.is_some());
+        assert!(!freshness.is_stale);
+    }
+
+    #[test]
+    fn test_from_timestamp_unparseable_is_stale() {
+        let freshness = DataFreshness::from_timestamp("HA", Some("not a date at all"), 3);
+        assert!(freshness.last_updated.is_none());
+        assert!(freshness.is_stale);
+        assert_eq!(freshness.age_display, "unknown");
+    }
+
+    #[test]
+    fn test_staleness_config_no_warnings() {
+        let config = StalenessConfig::no_warnings();
+        assert!(!config.warn_enabled);
+        assert!(!config.auto_update);
+        assert_eq!(config.threshold_days, DEFAULT_STALE_THRESHOLD_DAYS);
+    }
+
+    #[test]
+    fn test_staleness_config_with_auto_update() {
+        let config = StalenessConfig::with_auto_update();
+        assert!(config.auto_update);
+        assert!(config.warn_enabled);
+        assert_eq!(config.threshold_days, DEFAULT_STALE_THRESHOLD_DAYS);
+    }
+
+    #[test]
+    fn test_staleness_config_with_threshold() {
+        let config = StalenessConfig::with_threshold(10);
+        assert_eq!(config.threshold_days, 10);
+        assert!(config.warn_enabled);
+        assert!(!config.auto_update);
+    }
+
+    #[test]
+    fn test_parse_fcc_datetime_bad_time_component() {
+        // Day and month parse but the time field lacks three colon-separated parts.
+        assert!(parse_fcc_datetime("Tue Jan 13 0831 EST 2026").is_none());
+        // Out-of-range month abbreviation.
+        assert!(parse_fcc_datetime("Tue Foo 13 08:31:48 EST 2026").is_none());
+    }
+
+    #[test]
     fn test_freshness_from_fcc_format() {
         // FCC format: "Tue Jan 13 08:31:48 EST 2026"
         // This is older than 3 days from today (Jan 19), so should be stale

--- a/crates/uls-db/src/schema.rs
+++ b/crates/uls-db/src/schema.rs
@@ -496,6 +496,101 @@ mod tests {
     }
 
     #[test]
+    fn test_get_version_uninitialized() {
+        // A bare connection with no tables reports no schema version.
+        let conn = Connection::open_in_memory().unwrap();
+        assert_eq!(Schema::get_version(&conn).unwrap(), None);
+    }
+
+    #[test]
+    fn test_get_version_after_create_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        Schema::create_tables(&conn).unwrap();
+        assert_eq!(Schema::get_version(&conn).unwrap(), Some(SCHEMA_VERSION));
+    }
+
+    #[test]
+    fn test_migrate_uninitialized_is_noop() {
+        // Migration on an empty database leaves it uninitialized.
+        let conn = Connection::open_in_memory().unwrap();
+        Schema::migrate_if_needed(&conn).unwrap();
+        assert_eq!(Schema::get_version(&conn).unwrap(), None);
+    }
+
+    #[test]
+    fn test_migrate_current_version_is_noop() {
+        let conn = Connection::open_in_memory().unwrap();
+        Schema::initialize(&conn).unwrap();
+        Schema::migrate_if_needed(&conn).unwrap();
+        assert_eq!(Schema::get_version(&conn).unwrap(), Some(SCHEMA_VERSION));
+    }
+
+    #[test]
+    fn test_migrate_from_v4_adds_applied_patches_and_bumps_version() {
+        let conn = Connection::open_in_memory().unwrap();
+        Schema::create_tables(&conn).unwrap();
+
+        // Drop applied_patches and pin the recorded version to v4 to simulate
+        // an old database that predates the patch-tracking table.
+        conn.execute_batch("DROP TABLE applied_patches;").unwrap();
+        Schema::set_metadata(&conn, "schema_version", "4").unwrap();
+        assert_eq!(Schema::get_version(&conn).unwrap(), Some(4));
+
+        Schema::migrate_if_needed(&conn).unwrap();
+
+        // Version advances to current and the table is created by migrate_to_v5.
+        assert_eq!(Schema::get_version(&conn).unwrap(), Some(SCHEMA_VERSION));
+        let table_count: i32 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='applied_patches'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(table_count, 1);
+    }
+
+    #[test]
+    fn test_create_tables_makes_all_expected_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        Schema::create_tables(&conn).unwrap();
+
+        for table in [
+            "metadata",
+            "licenses",
+            "entities",
+            "amateur_operators",
+            "history",
+            "comments",
+            "special_conditions",
+            "import_status",
+            "applied_patches",
+        ] {
+            let count: i32 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [table],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "table {table} should exist");
+        }
+    }
+
+    #[test]
+    fn test_set_metadata_overwrites_existing() {
+        let conn = Connection::open_in_memory().unwrap();
+        Schema::initialize(&conn).unwrap();
+
+        Schema::set_metadata(&conn, "k", "first").unwrap();
+        Schema::set_metadata(&conn, "k", "second").unwrap();
+        assert_eq!(
+            Schema::get_metadata(&conn, "k").unwrap(),
+            Some("second".to_string())
+        );
+    }
+
+    #[test]
     fn test_drop_and_recreate_indexes() {
         let conn = Connection::open_in_memory().unwrap();
         Schema::initialize(&conn).unwrap();

--- a/crates/uls-db/tests/importer_service.rs
+++ b/crates/uls-db/tests/importer_service.rs
@@ -1,0 +1,254 @@
+//! Integration tests for service-scoped import and incremental patch apply.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+use zip::write::FileOptions;
+use zip::ZipWriter;
+
+use uls_db::{Database, DatabaseConfig, ImportMode, Importer};
+
+fn create_test_db() -> (TempDir, Database) {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let db = Database::with_config(DatabaseConfig::with_path(db_path)).unwrap();
+    db.initialize().unwrap();
+    (temp_dir, db)
+}
+
+/// Write a ZIP at `name` containing the given (filename, contents) DAT entries.
+fn write_zip(temp_dir: &TempDir, name: &str, entries: &[(&str, &[u8])]) -> PathBuf {
+    let zip_path = temp_dir.path().join(name);
+    let file = std::fs::File::create(&zip_path).unwrap();
+    let mut zip = ZipWriter::new(file);
+    let options: FileOptions<()> = FileOptions::default();
+    for (filename, contents) in entries {
+        zip.start_file(*filename, options).unwrap();
+        zip.write_all(contents).unwrap();
+    }
+    zip.finish().unwrap();
+    zip_path
+}
+
+/// Build an HD line for a single license.
+fn hd_line(usi: &str, callsign: &str, status: &str) -> String {
+    format!(
+        "HD|{usi}|0000000001||{callsign}|{status}|HA|01/15/2020|01/15/2030|||||||||||||||||||||||||||||||||||N|||||||||||01/15/2020|01/15/2020|||||||||||||||\n"
+    )
+}
+
+fn weekly_zip(temp_dir: &TempDir) -> PathBuf {
+    write_zip(
+        temp_dir,
+        "weekly.zip",
+        &[
+            ("HD.dat", hd_line("100001", "W1WEEK", "A").as_bytes()),
+            (
+                "EN.dat",
+                b"EN|100001|||W1WEEK|L|L00100001|DOE, JOHN|JOHN||DOE||||||||||||000|0001234567|I||||||\n",
+            ),
+            ("AM.dat", b"AM|100001|||W1WEEK|E|D|6||||||||||\n"),
+            ("HS.dat", b"HS|100001||W1WEEK|01/15/2020|LIISS\n"),
+        ],
+    )
+}
+
+// =============================================================================
+// import_for_service
+// =============================================================================
+
+#[test]
+fn test_import_for_service_records_import_status() {
+    let (temp_dir, db) = create_test_db();
+    let zip = weekly_zip(&temp_dir);
+
+    let importer = Importer::new(&db);
+    let stats = importer
+        .import_for_service(&zip, "HA", ImportMode::Full, None)
+        .unwrap();
+
+    assert!(stats.is_successful());
+    assert_eq!(stats.records, 4);
+
+    // Every record type present in the ZIP is marked imported for the service.
+    for rt in ["HD", "EN", "AM", "HS"] {
+        assert!(
+            db.has_record_type("HA", rt).unwrap(),
+            "{rt} should be marked imported"
+        );
+    }
+    let mut types = db.get_imported_types("HA").unwrap();
+    types.sort();
+    assert_eq!(types, vec!["AM", "EN", "HD", "HS"]);
+
+    assert!(db.get_license_by_callsign("W1WEEK").unwrap().is_some());
+}
+
+#[test]
+fn test_import_for_service_minimal_skips_history() {
+    let (temp_dir, db) = create_test_db();
+    let zip = weekly_zip(&temp_dir);
+
+    let importer = Importer::new(&db);
+    let stats = importer
+        .import_for_service(&zip, "HA", ImportMode::Minimal, None)
+        .unwrap();
+
+    // Minimal mode imports HD, EN, AM only.
+    assert_eq!(stats.files, 3);
+    assert_eq!(stats.records, 3);
+
+    assert!(db.has_record_type("HA", "HD").unwrap());
+    assert!(db.has_record_type("HA", "AM").unwrap());
+    assert!(!db.has_record_type("HA", "HS").unwrap());
+}
+
+#[test]
+fn test_import_for_service_clears_prior_status() {
+    let (temp_dir, db) = create_test_db();
+
+    // Pre-seed a stale status entry that a fresh import should clear.
+    db.mark_imported("HA", "LA", 999).unwrap();
+    assert!(db.has_record_type("HA", "LA").unwrap());
+
+    let zip = weekly_zip(&temp_dir);
+    let importer = Importer::new(&db);
+    importer
+        .import_for_service(&zip, "HA", ImportMode::Full, None)
+        .unwrap();
+
+    // The stale LA entry is gone; only types from this ZIP remain.
+    assert!(!db.has_record_type("HA", "LA").unwrap());
+    assert!(db.has_record_type("HA", "HD").unwrap());
+}
+
+// =============================================================================
+// import_patch (daily incremental)
+// =============================================================================
+
+#[test]
+fn test_import_patch_updates_existing_record() {
+    let (temp_dir, db) = create_test_db();
+
+    // Start with an active weekly record.
+    let importer = Importer::new(&db);
+    importer
+        .import_for_service(&weekly_zip(&temp_dir), "HA", ImportMode::Full, None)
+        .unwrap();
+    assert_eq!(
+        db.get_license_by_callsign("W1WEEK")
+            .unwrap()
+            .unwrap()
+            .status,
+        'A'
+    );
+
+    // Daily patch flips the same license (same USI) to cancelled.
+    let patch = write_zip(
+        &temp_dir,
+        "patch.zip",
+        &[("HD.dat", hd_line("100001", "W1WEEK", "C").as_bytes())],
+    );
+
+    let stats = importer
+        .import_patch(&patch, ImportMode::Full, None)
+        .unwrap();
+    assert!(stats.is_successful());
+    assert_eq!(stats.records, 1);
+    assert_eq!(stats.files, 1);
+
+    // INSERT OR REPLACE updated the row rather than adding a duplicate.
+    let license = db.get_license_by_callsign("W1WEEK").unwrap().unwrap();
+    assert_eq!(license.status, 'C');
+    assert_eq!(db.get_stats().unwrap().total_licenses, 1);
+}
+
+#[test]
+fn test_import_patch_adds_new_record() {
+    let (temp_dir, db) = create_test_db();
+    let importer = Importer::new(&db);
+    importer
+        .import_for_service(&weekly_zip(&temp_dir), "HA", ImportMode::Full, None)
+        .unwrap();
+
+    let patch = write_zip(
+        &temp_dir,
+        "patch_new.zip",
+        &[("HD.dat", hd_line("200002", "W2NEW", "A").as_bytes())],
+    );
+    let stats = importer
+        .import_patch(&patch, ImportMode::Full, None)
+        .unwrap();
+    assert_eq!(stats.records, 1);
+
+    assert!(db.get_license_by_callsign("W2NEW").unwrap().is_some());
+    assert_eq!(db.get_stats().unwrap().total_licenses, 2);
+}
+
+#[test]
+fn test_import_patch_does_not_clear_import_status() {
+    let (temp_dir, db) = create_test_db();
+    let importer = Importer::new(&db);
+    importer
+        .import_for_service(&weekly_zip(&temp_dir), "HA", ImportMode::Full, None)
+        .unwrap();
+    assert!(db.has_record_type("HA", "HD").unwrap());
+
+    let patch = write_zip(
+        &temp_dir,
+        "patch_status.zip",
+        &[("HD.dat", hd_line("100001", "W1WEEK", "A").as_bytes())],
+    );
+    importer
+        .import_patch(&patch, ImportMode::Full, None)
+        .unwrap();
+
+    // Patches are additive: prior import status remains intact.
+    assert!(db.has_record_type("HA", "HD").unwrap());
+    assert!(db.has_record_type("HA", "AM").unwrap());
+}
+
+// =============================================================================
+// Error paths
+// =============================================================================
+
+#[test]
+fn test_import_for_service_bad_zip_errors() {
+    let (temp_dir, db) = create_test_db();
+    let bogus = temp_dir.path().join("notazip.zip");
+    std::fs::write(&bogus, b"this is not a zip archive").unwrap();
+
+    let importer = Importer::new(&db);
+    let result = importer.import_for_service(&bogus, "HA", ImportMode::Full, None);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_import_patch_nonexistent_file_errors() {
+    let (_temp_dir, db) = create_test_db();
+    let importer = Importer::new(&db);
+
+    let result = importer.import_patch(Path::new("/nonexistent/patch.zip"), ImportMode::Full, None);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_import_zip_with_no_matching_files_imports_nothing() {
+    let (temp_dir, db) = create_test_db();
+
+    // ZIP contains only a record type that Minimal mode excludes.
+    let zip = write_zip(
+        &temp_dir,
+        "history_only.zip",
+        &[("HS.dat", b"HS|100001||W1WEEK|01/15/2020|LIISS\n")],
+    );
+
+    let importer = Importer::new(&db);
+    let stats = importer
+        .import_zip_with_mode(&zip, ImportMode::Minimal, None)
+        .unwrap();
+    assert_eq!(stats.files, 0);
+    assert_eq!(stats.records, 0);
+    assert!(stats.is_successful());
+}

--- a/crates/uls-db/tests/repository_queries.rs
+++ b/crates/uls-db/tests/repository_queries.rs
@@ -1,0 +1,366 @@
+//! Integration tests for Database query methods: freshness/patch tracking,
+//! stats aggregation, and FRN lookups against an in-memory database.
+
+use chrono::NaiveDate;
+
+use uls_core::records::{EntityRecord, HeaderRecord, UlsRecord};
+use uls_db::{Database, DatabaseConfig};
+
+/// Create an in-memory database for query tests.
+fn create_test_db() -> Database {
+    let db = Database::with_config(DatabaseConfig::in_memory()).unwrap();
+    db.initialize().unwrap();
+    db
+}
+
+/// Build a header record with explicit identifiers and status.
+fn header(usi: i64, callsign: &str, status: char, service: &str) -> HeaderRecord {
+    let mut hd = HeaderRecord::from_fields(&["HD", &usi.to_string()]);
+    hd.unique_system_identifier = usi;
+    hd.call_sign = Some(callsign.to_string());
+    hd.license_status = Some(status);
+    hd.radio_service_code = Some(service.to_string());
+    hd
+}
+
+/// Build an entity record carrying the given FRN for a license.
+fn entity_with_frn(usi: i64, callsign: &str, frn: &str) -> EntityRecord {
+    EntityRecord::from_fields(&[
+        "EN",
+        &usi.to_string(),
+        "",
+        "",
+        callsign,
+        "L",
+        "L00100001",
+        "DOE, JOHN A",
+        "JOHN",
+        "A",
+        "DOE",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "000",
+        frn,
+        "I",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+    ])
+}
+
+// =============================================================================
+// Stats aggregation
+// =============================================================================
+
+#[test]
+fn test_stats_counts_each_status() {
+    let db = create_test_db();
+    db.insert_record(&UlsRecord::Header(header(1, "W1A", 'A', "HA")))
+        .unwrap();
+    db.insert_record(&UlsRecord::Header(header(2, "W2A", 'A', "HA")))
+        .unwrap();
+    db.insert_record(&UlsRecord::Header(header(3, "W3E", 'E', "HA")))
+        .unwrap();
+    db.insert_record(&UlsRecord::Header(header(4, "W4C", 'C', "HA")))
+        .unwrap();
+
+    let stats = db.get_stats().unwrap();
+    assert_eq!(stats.total_licenses, 4);
+    assert_eq!(stats.active_licenses, 2);
+    assert_eq!(stats.expired_licenses, 1);
+    assert_eq!(stats.cancelled_licenses, 1);
+    assert_eq!(stats.schema_version, uls_db::schema::SCHEMA_VERSION);
+}
+
+#[test]
+fn test_stats_last_updated_reflects_metadata() {
+    let db = create_test_db();
+
+    let stats = db.get_stats().unwrap();
+    assert!(stats.last_updated.is_none());
+
+    db.set_last_updated("2026-01-13T08:00:00Z").unwrap();
+    let stats = db.get_stats().unwrap();
+    assert_eq!(stats.last_updated, Some("2026-01-13T08:00:00Z".to_string()));
+}
+
+#[test]
+fn test_stats_empty_database() {
+    let db = create_test_db();
+    let stats = db.get_stats().unwrap();
+    assert_eq!(stats.total_licenses, 0);
+    assert_eq!(stats.active_licenses, 0);
+    assert_eq!(stats.expired_licenses, 0);
+    assert_eq!(stats.cancelled_licenses, 0);
+}
+
+// =============================================================================
+// FRN lookups
+// =============================================================================
+
+#[test]
+fn test_get_licenses_by_frn_returns_all_matches() {
+    let db = create_test_db();
+
+    // Two licenses share one FRN, a third has a different FRN.
+    db.insert_record(&UlsRecord::Header(header(10, "AAA", 'A', "HA")))
+        .unwrap();
+    db.insert_record(&UlsRecord::Entity(entity_with_frn(10, "AAA", "0009999999")))
+        .unwrap();
+
+    db.insert_record(&UlsRecord::Header(header(11, "BBB", 'A', "ZA")))
+        .unwrap();
+    db.insert_record(&UlsRecord::Entity(entity_with_frn(11, "BBB", "0009999999")))
+        .unwrap();
+
+    db.insert_record(&UlsRecord::Header(header(12, "CCC", 'A', "HA")))
+        .unwrap();
+    db.insert_record(&UlsRecord::Entity(entity_with_frn(12, "CCC", "0001111111")))
+        .unwrap();
+
+    let licenses = db.get_licenses_by_frn("0009999999").unwrap();
+    assert_eq!(licenses.len(), 2);
+    let callsigns: Vec<&str> = licenses.iter().map(|l| l.call_sign.as_str()).collect();
+    assert!(callsigns.contains(&"AAA"));
+    assert!(callsigns.contains(&"BBB"));
+    for license in &licenses {
+        assert_eq!(license.frn.as_deref(), Some("0009999999"));
+    }
+}
+
+#[test]
+fn test_get_licenses_by_frn_trims_input() {
+    let db = create_test_db();
+    db.insert_record(&UlsRecord::Header(header(20, "DDD", 'A', "HA")))
+        .unwrap();
+    db.insert_record(&UlsRecord::Entity(entity_with_frn(20, "DDD", "0002222222")))
+        .unwrap();
+
+    let licenses = db.get_licenses_by_frn("  0002222222  ").unwrap();
+    assert_eq!(licenses.len(), 1);
+    assert_eq!(licenses[0].call_sign, "DDD");
+}
+
+#[test]
+fn test_get_licenses_by_frn_empty_when_no_entity() {
+    let db = create_test_db();
+    // Header with no entity row: the INNER JOIN on entities yields nothing.
+    db.insert_record(&UlsRecord::Header(header(30, "EEE", 'A', "HA")))
+        .unwrap();
+
+    let licenses = db.get_licenses_by_frn("0001234567").unwrap();
+    assert!(licenses.is_empty());
+}
+
+// =============================================================================
+// count_by_service edge cases
+// =============================================================================
+
+#[test]
+fn test_count_by_service_multiple_codes() {
+    let db = create_test_db();
+    db.insert_record(&UlsRecord::Header(header(40, "HAM1", 'A', "HA")))
+        .unwrap();
+    db.insert_record(&UlsRecord::Header(header(41, "HAM2", 'A', "HV")))
+        .unwrap();
+    db.insert_record(&UlsRecord::Header(header(42, "GM1", 'A', "ZA")))
+        .unwrap();
+
+    assert_eq!(db.count_by_service(&["HA", "HV"]).unwrap(), 2);
+    assert_eq!(db.count_by_service(&["ZA"]).unwrap(), 1);
+    assert_eq!(db.count_by_service(&["HA", "HV", "ZA"]).unwrap(), 3);
+}
+
+#[test]
+fn test_count_by_service_unknown_code_returns_zero() {
+    let db = create_test_db();
+    db.insert_record(&UlsRecord::Header(header(50, "X1", 'A', "HA")))
+        .unwrap();
+
+    // "QQ" is not a recognized RadioService, so it filters out to no codes.
+    assert_eq!(db.count_by_service(&["QQ"]).unwrap(), 0);
+}
+
+// =============================================================================
+// Last-updated / last-weekly metadata
+// =============================================================================
+
+#[test]
+fn test_last_updated_roundtrip() {
+    let db = create_test_db();
+    assert!(db.get_last_updated().unwrap().is_none());
+
+    db.set_last_updated("2026-01-13 08:00:00 UTC").unwrap();
+    assert_eq!(
+        db.get_last_updated().unwrap(),
+        Some("2026-01-13 08:00:00 UTC".to_string())
+    );
+}
+
+#[test]
+fn test_last_weekly_date_roundtrip_per_service() {
+    let db = create_test_db();
+    assert!(db.get_last_weekly_date("HA").unwrap().is_none());
+
+    let date = NaiveDate::from_ymd_opt(2026, 1, 4).unwrap();
+    db.set_last_weekly_date("HA", date).unwrap();
+
+    assert_eq!(db.get_last_weekly_date("HA").unwrap(), Some(date));
+    // A different service has its own slot.
+    assert!(db.get_last_weekly_date("ZA").unwrap().is_none());
+}
+
+// =============================================================================
+// Applied patch tracking
+// =============================================================================
+
+#[test]
+fn test_applied_patches_record_and_order() {
+    let db = create_test_db();
+
+    // Insert out of date order to verify the query sorts by patch_date.
+    db.record_applied_patch(
+        "HA",
+        NaiveDate::from_ymd_opt(2026, 1, 8).unwrap(),
+        "thu",
+        Some("etag-thu"),
+        Some(120),
+    )
+    .unwrap();
+    db.record_applied_patch(
+        "HA",
+        NaiveDate::from_ymd_opt(2026, 1, 6).unwrap(),
+        "tue",
+        None,
+        Some(80),
+    )
+    .unwrap();
+
+    let patches = db.get_applied_patches("HA").unwrap();
+    assert_eq!(patches.len(), 2);
+    assert_eq!(
+        patches[0].patch_date,
+        NaiveDate::from_ymd_opt(2026, 1, 6).unwrap()
+    );
+    assert_eq!(
+        patches[1].patch_date,
+        NaiveDate::from_ymd_opt(2026, 1, 8).unwrap()
+    );
+
+    assert_eq!(patches[0].weekday, "tue");
+    assert_eq!(patches[0].etag, None);
+    assert_eq!(patches[0].record_count, Some(80));
+
+    assert_eq!(patches[1].weekday, "thu");
+    assert_eq!(patches[1].etag, Some("etag-thu".to_string()));
+    assert_eq!(patches[1].record_count, Some(120));
+}
+
+#[test]
+fn test_applied_patch_replace_same_date() {
+    let db = create_test_db();
+    let date = NaiveDate::from_ymd_opt(2026, 1, 9).unwrap();
+
+    db.record_applied_patch("HA", date, "fri", Some("old"), Some(10))
+        .unwrap();
+    db.record_applied_patch("HA", date, "fri", Some("new"), Some(99))
+        .unwrap();
+
+    let patches = db.get_applied_patches("HA").unwrap();
+    assert_eq!(patches.len(), 1);
+    assert_eq!(patches[0].etag, Some("new".to_string()));
+    assert_eq!(patches[0].record_count, Some(99));
+}
+
+#[test]
+fn test_clear_applied_patches_only_targets_service() {
+    let db = create_test_db();
+    db.record_applied_patch(
+        "HA",
+        NaiveDate::from_ymd_opt(2026, 1, 6).unwrap(),
+        "tue",
+        None,
+        None,
+    )
+    .unwrap();
+    db.record_applied_patch(
+        "ZA",
+        NaiveDate::from_ymd_opt(2026, 1, 6).unwrap(),
+        "tue",
+        None,
+        None,
+    )
+    .unwrap();
+
+    db.clear_applied_patches("HA").unwrap();
+
+    assert!(db.get_applied_patches("HA").unwrap().is_empty());
+    assert_eq!(db.get_applied_patches("ZA").unwrap().len(), 1);
+}
+
+#[test]
+fn test_get_applied_patches_empty_for_unknown_service() {
+    let db = create_test_db();
+    assert!(db.get_applied_patches("HA").unwrap().is_empty());
+}
+
+// =============================================================================
+// Freshness composition and staleness
+// =============================================================================
+
+#[test]
+fn test_get_freshness_combines_metadata_and_patches() {
+    let db = create_test_db();
+
+    db.set_last_updated("2026-01-13 08:00:00 UTC").unwrap();
+    db.set_last_weekly_date("HA", NaiveDate::from_ymd_opt(2026, 1, 4).unwrap())
+        .unwrap();
+    db.record_applied_patch(
+        "HA",
+        NaiveDate::from_ymd_opt(2026, 1, 6).unwrap(),
+        "tue",
+        None,
+        Some(5),
+    )
+    .unwrap();
+
+    let freshness = db.get_freshness("HA", 3).unwrap();
+    assert_eq!(freshness.service, "HA");
+    assert_eq!(
+        freshness.last_weekly_date,
+        Some(NaiveDate::from_ymd_opt(2026, 1, 4).unwrap())
+    );
+    assert_eq!(
+        freshness.applied_patch_dates,
+        vec![NaiveDate::from_ymd_opt(2026, 1, 6).unwrap()]
+    );
+    assert!(freshness.last_updated.is_some());
+}
+
+#[test]
+fn test_is_stale_when_no_timestamp() {
+    let db = create_test_db();
+    // No last_updated metadata means the data is treated as stale.
+    assert!(db.is_stale("HA", 3).unwrap());
+}
+
+#[test]
+fn test_is_stale_false_for_recent_update() {
+    let db = create_test_db();
+    let now = chrono::Utc::now()
+        .format("%Y-%m-%d %H:%M:%S UTC")
+        .to_string();
+    db.set_last_updated(&now).unwrap();
+    assert!(!db.is_stale("HA", 3).unwrap());
+}

--- a/crates/uls-download/src/catalog.rs
+++ b/crates/uls-download/src/catalog.rs
@@ -503,6 +503,144 @@ mod tests {
     }
 
     #[test]
+    fn test_datafile_display_uses_filename() {
+        let complete = DataFile::complete_license("amat");
+        assert_eq!(complete.to_string(), "l_amat.zip");
+
+        let daily = DataFile::daily_license("gmrs", Weekday::Wednesday);
+        assert_eq!(daily.to_string(), "l_gm_wed.zip");
+
+        let application = DataFile::complete_application("amat");
+        assert_eq!(application.to_string(), "a_amat.zip");
+    }
+
+    #[test]
+    fn test_complete_application_via_catalog_known_and_unknown() {
+        let file = ServiceCatalog::complete_application("amat").unwrap();
+        assert_eq!(file.filename(), "a_amat.zip");
+        assert_eq!(file.url_path(), "complete/a_amat.zip");
+
+        // Radio service code resolves to the full name as well.
+        let by_code = ServiceCatalog::complete_application("HA").unwrap();
+        assert_eq!(by_code.filename(), "a_amat.zip");
+
+        let err = ServiceCatalog::complete_application("nope").unwrap_err();
+        assert!(matches!(err, DownloadError::UnknownService(s) if s == "nope"));
+    }
+
+    #[test]
+    fn test_full_name_unknown_returns_none() {
+        assert_eq!(ServiceCatalog::full_name("amat"), Some("amat"));
+        assert_eq!(ServiceCatalog::full_name("gm"), Some("gmrs"));
+        assert_eq!(ServiceCatalog::full_name("ZA"), Some("gmrs"));
+        assert_eq!(ServiceCatalog::full_name("not-a-service"), None);
+    }
+
+    #[test]
+    fn test_daily_abbreviation_unknown_returns_placeholder() {
+        assert_eq!(ServiceCatalog::daily_abbreviation("ship"), "sh");
+        assert_eq!(ServiceCatalog::daily_abbreviation("does-not-exist"), "xx");
+    }
+
+    #[test]
+    fn test_unknown_service_daily_filename_uses_placeholder() {
+        // An unknown service still produces a (placeholder) daily filename.
+        let file = DataFile::daily_license("mystery", Weekday::Tuesday);
+        assert_eq!(file.filename(), "l_xx_tue.zip");
+    }
+
+    #[test]
+    fn test_all_services_metadata() {
+        let services = ServiceCatalog::all_services();
+        assert_eq!(services.len(), 9);
+
+        let amat = services.iter().find(|s| s.name == "amat").unwrap();
+        assert_eq!(amat.daily_abbrev, "am");
+        assert_eq!(amat.description, "Amateur Radio");
+        assert_eq!(amat.radio_service_codes, vec!["HA", "HV"]);
+
+        let market = services.iter().find(|s| s.name == "market").unwrap();
+        assert!(market.radio_service_codes.is_empty());
+    }
+
+    #[test]
+    fn test_daily_licenses_lists_all_seven_days() {
+        let files = ServiceCatalog::daily_licenses("amat").unwrap();
+        let names: Vec<String> = files.iter().map(|f| f.filename()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "l_am_sun.zip",
+                "l_am_mon.zip",
+                "l_am_tue.zip",
+                "l_am_wed.zip",
+                "l_am_thu.zip",
+                "l_am_fri.zip",
+                "l_am_sat.zip",
+            ]
+        );
+
+        assert!(ServiceCatalog::daily_licenses("nope").is_err());
+    }
+
+    #[test]
+    fn test_weekday_all_ordering_and_abbrevs() {
+        assert_eq!(Weekday::ALL.len(), 7);
+        let abbrevs: Vec<&str> = Weekday::ALL.iter().map(|d| d.abbrev()).collect();
+        assert_eq!(
+            abbrevs,
+            vec!["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
+        );
+    }
+
+    #[rstest::rstest]
+    #[case(chrono::Weekday::Sun, Weekday::Sunday, "sun")]
+    #[case(chrono::Weekday::Mon, Weekday::Monday, "mon")]
+    #[case(chrono::Weekday::Tue, Weekday::Tuesday, "tue")]
+    #[case(chrono::Weekday::Wed, Weekday::Wednesday, "wed")]
+    #[case(chrono::Weekday::Thu, Weekday::Thursday, "thu")]
+    #[case(chrono::Weekday::Fri, Weekday::Friday, "fri")]
+    #[case(chrono::Weekday::Sat, Weekday::Saturday, "sat")]
+    fn test_weekday_from_chrono_and_abbrev(
+        #[case] chrono_day: chrono::Weekday,
+        #[case] expected: Weekday,
+        #[case] abbrev: &str,
+    ) {
+        assert_eq!(Weekday::from_chrono(chrono_day), expected);
+        assert_eq!(expected.abbrev(), abbrev);
+    }
+
+    #[rstest::rstest]
+    // 2026-01-11 is a Sunday; each subsequent date advances one weekday.
+    #[case(11, Weekday::Sunday)]
+    #[case(12, Weekday::Monday)]
+    #[case(13, Weekday::Tuesday)]
+    #[case(14, Weekday::Wednesday)]
+    #[case(15, Weekday::Thursday)]
+    #[case(16, Weekday::Friday)]
+    #[case(17, Weekday::Saturday)]
+    fn test_weekday_for_date(#[case] day_of_month: u32, #[case] expected: Weekday) {
+        let date = NaiveDate::from_ymd_opt(2026, 1, day_of_month).unwrap();
+        assert_eq!(Weekday::for_date(date), expected);
+    }
+
+    #[test]
+    fn test_get_missing_daily_files_unknown_service_errors() {
+        let weekly = NaiveDate::from_ymd_opt(2026, 1, 11).unwrap();
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
+        assert!(ServiceCatalog::get_missing_daily_files("nope", weekly, &[], today).is_err());
+    }
+
+    #[test]
+    fn test_get_missing_daily_files_none_when_caught_up() {
+        // Weekly imported today, nothing newer to apply.
+        let weekly = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
+        let today = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
+        let missing = ServiceCatalog::get_missing_daily_files("amat", weekly, &[], today).unwrap();
+        assert!(missing.is_empty());
+    }
+
+    #[test]
     fn test_get_missing_daily_files_second_week_with_first_week_applied() {
         // Weekly on Sun Jan 11, all of week 1 (Mon-Sun) applied, now it's Thu Jan 22
         let weekly = NaiveDate::from_ymd_opt(2026, 1, 11).unwrap();

--- a/crates/uls-download/src/config.rs
+++ b/crates/uls-download/src/config.rs
@@ -119,4 +119,29 @@ mod tests {
         assert_eq!(config.timeout, Duration::from_secs(60));
         assert_eq!(config.bandwidth_limit, 1_000_000);
     }
+
+    #[test]
+    fn test_with_cache_dir_keeps_other_defaults() {
+        let config = DownloadConfig::with_cache_dir(PathBuf::from("/tmp/uls-cache"));
+        assert_eq!(config.cache_dir, PathBuf::from("/tmp/uls-cache"));
+        // Remaining fields fall back to the defaults.
+        assert_eq!(config.max_retries, 3);
+        assert!(config.verify_ssl);
+        assert_eq!(config.timeout, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn test_full_builder_chain() {
+        let config = DownloadConfig::with_cache_dir(PathBuf::from("/var/cache/uls"))
+            .with_base_url("https://example.test")
+            .with_timeout(Duration::from_secs(10))
+            .with_user_agent("agent")
+            .with_bandwidth_limit(2_048);
+
+        assert_eq!(config.cache_dir, PathBuf::from("/var/cache/uls"));
+        assert_eq!(config.base_url, "https://example.test");
+        assert_eq!(config.timeout, Duration::from_secs(10));
+        assert_eq!(config.user_agent, "agent");
+        assert_eq!(config.bandwidth_limit, 2_048);
+    }
 }

--- a/crates/uls-download/src/progress.rs
+++ b/crates/uls-download/src/progress.rs
@@ -132,4 +132,54 @@ mod tests {
 
         assert_eq!(progress.size_string(), "512.0 KB / 1.00 MB");
     }
+
+    #[test]
+    fn test_size_string_unknown_total() {
+        let mut progress = DownloadProgress::new("test.zip", None);
+        progress.downloaded_bytes = 2048;
+        assert_eq!(progress.size_string(), "2.0 KB");
+    }
+
+    #[test]
+    fn test_fraction_zero_total_is_complete() {
+        // A zero-length file is treated as fully downloaded.
+        let progress = DownloadProgress::new("empty.zip", Some(0));
+        assert_eq!(progress.fraction(), Some(1.0));
+        assert_eq!(progress.percent(), Some(100));
+    }
+
+    #[test]
+    fn test_percent_clamped_to_100() {
+        // Overshooting the reported total still caps at 100 percent.
+        let mut progress = DownloadProgress::new("test.zip", Some(1000));
+        progress.downloaded_bytes = 1500;
+        assert_eq!(progress.percent(), Some(100));
+    }
+
+    #[test]
+    fn test_speed_string() {
+        let mut progress = DownloadProgress::new("test.zip", None);
+        progress.speed_bps = 1024 * 1024;
+        assert_eq!(progress.speed_string(), "1.00 MB/s");
+
+        progress.speed_bps = 500;
+        assert_eq!(progress.speed_string(), "500 B/s");
+    }
+
+    #[test]
+    fn test_format_bytes_per_second() {
+        assert_eq!(format_bytes_per_second(0), "0 B/s");
+        assert_eq!(format_bytes_per_second(1024), "1.0 KB/s");
+        assert_eq!(format_bytes_per_second(1024 * 1024 * 1024), "1.00 GB/s");
+    }
+
+    #[test]
+    fn test_new_initializes_fields() {
+        let progress = DownloadProgress::new("file.zip", Some(99));
+        assert_eq!(progress.filename, "file.zip");
+        assert_eq!(progress.total_bytes, Some(99));
+        assert_eq!(progress.downloaded_bytes, 0);
+        assert_eq!(progress.speed_bps, 0);
+        assert_eq!(progress.eta_seconds, None);
+    }
 }

--- a/crates/uls-download/tests/client_behavior.rs
+++ b/crates/uls-download/tests/client_behavior.rs
@@ -1,0 +1,572 @@
+//! Additional integration tests for FccClient covering download branches not
+//! exercised by download_integration.rs: content-length handling, incomplete
+//! downloads, retry exhaustion, daily-file fan-out, and cached-metadata helpers.
+
+use std::io::Write;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use uls_download::{DownloadConfig, DownloadError, DownloadResult, FccClient, ServiceCatalog};
+
+/// Helper to create a minimal valid ZIP file for tests.
+fn create_test_zip(content: &[u8]) -> Vec<u8> {
+    use std::io::Cursor;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    let mut buffer = Cursor::new(Vec::new());
+    let mut zip = ZipWriter::new(&mut buffer);
+    let options = SimpleFileOptions::default();
+    zip.start_file("HD.dat", options).unwrap();
+    zip.write_all(content).unwrap();
+    zip.finish().unwrap();
+    buffer.into_inner()
+}
+
+/// Create a test client pointed at the wiremock server.
+fn create_test_client(cache_dir: &std::path::Path, server_uri: &str) -> FccClient {
+    let config = DownloadConfig::with_cache_dir(cache_dir.to_path_buf())
+        .with_base_url(server_uri)
+        .with_timeout(Duration::from_secs(10));
+    FccClient::new(config).expect("Failed to create test client")
+}
+
+fn noop() -> uls_download::ProgressCallback {
+    std::sync::Arc::new(|_| {})
+}
+
+// =============================================================================
+// Content-Length handling
+// =============================================================================
+
+#[tokio::test]
+async fn test_download_succeeds_without_content_length() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), &mock_server.uri());
+
+    let zip_content = create_test_zip(b"HD|1|EN|12345|W1AW|");
+
+    // No Content-Length header: size cannot be verified, download still succeeds.
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(zip_content.clone()))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let file = ServiceCatalog::complete_license("amat").unwrap();
+    let (path, result) = client.download_file(&file, noop()).await.unwrap();
+
+    assert_eq!(result, DownloadResult::Downloaded);
+    assert_eq!(std::fs::read(&path).unwrap(), zip_content);
+}
+
+// =============================================================================
+// Status-code mapping
+// =============================================================================
+
+#[tokio::test]
+async fn test_server_error_maps_status_and_url() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+
+    // Disable retries so a single 503 surfaces immediately.
+    let config = DownloadConfig::with_cache_dir(temp_dir.path().to_path_buf())
+        .with_base_url(mock_server.uri())
+        .with_timeout(Duration::from_secs(10));
+    let mut config = config;
+    config.max_retries = 0;
+    let client = FccClient::new(config).unwrap();
+
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(ResponseTemplate::new(503))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let file = ServiceCatalog::complete_license("amat").unwrap();
+    let err = client.download_file(&file, noop()).await.unwrap_err();
+
+    match err {
+        DownloadError::ServerError { status, url } => {
+            assert_eq!(status, 503);
+            assert!(url.ends_with("/complete/l_amat.zip"), "url was {url}");
+        }
+        other => panic!("expected ServerError, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_not_found_short_circuits_without_retry() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), &mock_server.uri());
+
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_clone = hits.clone();
+
+    // 404 must not be retried even though max_retries defaults to 3.
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(move |_: &wiremock::Request| {
+            hits_clone.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(404)
+        })
+        .mount(&mock_server)
+        .await;
+
+    let file = ServiceCatalog::complete_license("amat").unwrap();
+    let err = client.download_file(&file, noop()).await.unwrap_err();
+
+    assert!(matches!(err, DownloadError::NotFound { .. }));
+    assert_eq!(hits.load(Ordering::SeqCst), 1, "404 should not be retried");
+}
+
+// =============================================================================
+// Retry behavior with controlled time
+// =============================================================================
+
+#[tokio::test]
+async fn test_retry_then_success() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+
+    let config = DownloadConfig::with_cache_dir(temp_dir.path().to_path_buf())
+        .with_base_url(mock_server.uri())
+        .with_timeout(Duration::from_secs(10));
+    let mut config = config;
+    config.max_retries = 3;
+    config.retry_delay = Duration::from_millis(10);
+    let client = FccClient::new(config).unwrap();
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_clone = count.clone();
+    let zip_content = create_test_zip(b"HD|1|EN|12345|W1AW|");
+
+    // First attempt 500, second attempt succeeds.
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(move |_: &wiremock::Request| {
+            let n = count_clone.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                ResponseTemplate::new(500)
+            } else {
+                ResponseTemplate::new(200)
+                    .set_body_bytes(zip_content.clone())
+                    .insert_header("Content-Length", zip_content.len().to_string())
+            }
+        })
+        .mount(&mock_server)
+        .await;
+
+    let file = ServiceCatalog::complete_license("amat").unwrap();
+    let (_, result) = client.download_file(&file, noop()).await.unwrap();
+
+    assert_eq!(result, DownloadResult::Downloaded);
+    assert_eq!(count.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn test_retry_exhaustion_returns_last_error() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+
+    let config = DownloadConfig::with_cache_dir(temp_dir.path().to_path_buf())
+        .with_base_url(mock_server.uri())
+        .with_timeout(Duration::from_secs(10));
+    let mut config = config;
+    config.max_retries = 2;
+    config.retry_delay = Duration::from_millis(10);
+    let client = FccClient::new(config).unwrap();
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let count_clone = count.clone();
+
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(move |_: &wiremock::Request| {
+            count_clone.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(500)
+        })
+        .mount(&mock_server)
+        .await;
+
+    let file = ServiceCatalog::complete_license("amat").unwrap();
+    let err = client.download_file(&file, noop()).await.unwrap_err();
+
+    assert!(matches!(
+        err,
+        DownloadError::ServerError { status: 500, .. }
+    ));
+    // Initial attempt plus 2 retries = 3 requests.
+    assert_eq!(count.load(Ordering::SeqCst), 3);
+}
+
+// =============================================================================
+// Daily file fan-out
+// =============================================================================
+
+#[tokio::test]
+async fn test_download_all_daily_skips_missing_days() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), &mock_server.uri());
+
+    let zip_content = create_test_zip(b"daily");
+
+    // Monday and Friday are present; the rest 404 and must be skipped.
+    for day in ["mon", "fri"] {
+        Mock::given(method("GET"))
+            .and(path(format!("/daily/l_am_{day}.zip")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_bytes(zip_content.clone())
+                    .insert_header("Content-Length", zip_content.len().to_string()),
+            )
+            .mount(&mock_server)
+            .await;
+    }
+    for day in ["sun", "tue", "wed", "thu", "sat"] {
+        Mock::given(method("GET"))
+            .and(path(format!("/daily/l_am_{day}.zip")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&mock_server)
+            .await;
+    }
+
+    let paths = client.download_all_daily("amat").await.unwrap();
+    assert_eq!(paths.len(), 2);
+    let names: Vec<String> = paths
+        .iter()
+        .map(|p| p.file_name().unwrap().to_str().unwrap().to_string())
+        .collect();
+    assert!(names.contains(&"l_am_mon.zip".to_string()));
+    assert!(names.contains(&"l_am_fri.zip".to_string()));
+}
+
+#[tokio::test]
+async fn test_download_all_daily_propagates_server_error() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+
+    // No retries so the 500 surfaces from the fan-out promptly.
+    let mut config = DownloadConfig::with_cache_dir(temp_dir.path().to_path_buf())
+        .with_base_url(mock_server.uri())
+        .with_timeout(Duration::from_secs(10));
+    config.max_retries = 0;
+    let client = FccClient::new(config).unwrap();
+
+    // Sunday (first in Weekday::ALL) returns 500.
+    Mock::given(method("GET"))
+        .and(path("/daily/l_am_sun.zip"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&mock_server)
+        .await;
+
+    let err = client.download_all_daily("amat").await.unwrap_err();
+    assert!(matches!(
+        err,
+        DownloadError::ServerError { status: 500, .. }
+    ));
+}
+
+#[tokio::test]
+async fn test_download_daily_for_date() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), &mock_server.uri());
+
+    let zip_content = create_test_zip(b"wednesday");
+
+    // 2026-01-14 is a Wednesday.
+    Mock::given(method("GET"))
+        .and(path("/daily/l_am_wed.zip"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_content.clone())
+                .insert_header("Content-Length", zip_content.len().to_string()),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 14).unwrap();
+    let path = client.download_daily_for_date("amat", date).await.unwrap();
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "l_am_wed.zip");
+}
+
+#[tokio::test]
+async fn test_download_applications() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), &mock_server.uri());
+
+    let zip_content = create_test_zip(b"apps");
+
+    Mock::given(method("GET"))
+        .and(path("/complete/a_amat.zip"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_content.clone())
+                .insert_header("Content-Length", zip_content.len().to_string()),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let path = client.download_applications("amat").await.unwrap();
+    assert_eq!(path.file_name().unwrap().to_str().unwrap(), "a_amat.zip");
+}
+
+// =============================================================================
+// Cached metadata helpers
+// =============================================================================
+
+#[tokio::test]
+async fn test_get_cached_etag_none_then_some() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), &mock_server.uri());
+
+    let file = ServiceCatalog::complete_license("amat").unwrap();
+    // Nothing cached yet.
+    assert_eq!(client.get_cached_etag(&file), None);
+
+    let zip_content = create_test_zip(b"data");
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_content.clone())
+                .insert_header("Content-Length", zip_content.len().to_string())
+                .insert_header("ETag", "\"abc-123\""),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    client.download_complete("amat").await.unwrap();
+    assert_eq!(
+        client.get_cached_etag(&file),
+        Some("\"abc-123\"".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_get_cached_file_date_none_then_some() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), &mock_server.uri());
+
+    let file = ServiceCatalog::complete_license("amat").unwrap();
+    assert!(client.get_cached_file_date(&file).is_none());
+
+    let zip_content = create_test_zip(b"data");
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_content.clone())
+                .insert_header("Content-Length", zip_content.len().to_string()),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    client.download_complete("amat").await.unwrap();
+    assert!(client.get_cached_file_date(&file).is_some());
+}
+
+#[tokio::test]
+async fn test_stale_etag_ignored_when_data_file_missing() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), &mock_server.uri());
+
+    // Plant a stray .etag without the corresponding data file.
+    let etag_path = temp_dir.path().join("l_amat.zip.etag");
+    std::fs::write(&etag_path, "\"stale-etag\"").unwrap();
+
+    let head_hits = Arc::new(AtomicUsize::new(0));
+    let head_hits_clone = head_hits.clone();
+    Mock::given(method("HEAD"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(move |_: &wiremock::Request| {
+            head_hits_clone.fetch_add(1, Ordering::SeqCst);
+            ResponseTemplate::new(200).insert_header("ETag", "\"stale-etag\"")
+        })
+        .mount(&mock_server)
+        .await;
+
+    let zip_content = create_test_zip(b"fresh");
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_content.clone())
+                .insert_header("Content-Length", zip_content.len().to_string())
+                .insert_header("ETag", "\"stale-etag\""),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let file = ServiceCatalog::complete_license("amat").unwrap();
+    let (_, result) = client.download_file(&file, noop()).await.unwrap();
+
+    // Missing data file means the cached ETag is ignored: no HEAD probe, full GET.
+    assert_eq!(result, DownloadResult::Downloaded);
+    assert_eq!(head_hits.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn test_changed_head_etag_then_304_returns_not_modified() {
+    // Cache file present with matching ETag but HEAD reports a different ETag,
+    // forcing a conditional GET that the server answers with 304.
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), &mock_server.uri());
+
+    let zip_content = create_test_zip(b"v1");
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_content.clone())
+                .insert_header("Content-Length", zip_content.len().to_string())
+                .insert_header("ETag", "\"v1\""),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+    client.download_complete("amat").await.unwrap();
+    mock_server.reset().await;
+
+    // HEAD says the remote changed, so a conditional GET fires; server replies 304.
+    Mock::given(method("HEAD"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(ResponseTemplate::new(200).insert_header("ETag", "\"v2\""))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(ResponseTemplate::new(304))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let file = ServiceCatalog::complete_license("amat").unwrap();
+    let (_, result) = client.download_file(&file, noop()).await.unwrap();
+    assert_eq!(result, DownloadResult::NotModified);
+}
+
+// =============================================================================
+// check_for_updates error path
+// =============================================================================
+
+#[tokio::test]
+async fn test_check_for_updates_server_error() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), &mock_server.uri());
+
+    Mock::given(method("HEAD"))
+        .and(path("/complete/l_amat.zip"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let err = client.check_for_updates("amat").await.unwrap_err();
+    assert!(matches!(
+        err,
+        DownloadError::ServerError { status: 500, .. }
+    ));
+}
+
+#[tokio::test]
+async fn test_check_for_updates_unknown_service() {
+    let temp_dir = TempDir::new().unwrap();
+    let client = create_test_client(temp_dir.path(), "http://localhost:1");
+    let err = client.check_for_updates("not-a-service").await.unwrap_err();
+    assert!(matches!(err, DownloadError::UnknownService(_)));
+}
+
+// =============================================================================
+// Constructor / config interaction
+// =============================================================================
+
+#[test]
+fn test_new_creates_missing_cache_dir() {
+    let temp_dir = TempDir::new().unwrap();
+    let nested = temp_dir.path().join("a").join("b").join("cache");
+    assert!(!nested.exists());
+
+    let config = DownloadConfig::with_cache_dir(nested.clone());
+    let _client = FccClient::new(config).unwrap();
+    assert!(nested.exists());
+}
+
+#[tokio::test]
+async fn test_invalid_user_agent_falls_back_to_default_agent() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().unwrap();
+
+    // A header value containing control characters cannot be parsed; the client
+    // substitutes the DEFAULT_USER_AGENT fallback. The GET only matches when that
+    // exact agent is sent, so a successful download proves the substitution.
+    let config = DownloadConfig::with_cache_dir(temp_dir.path().to_path_buf())
+        .with_base_url(mock_server.uri())
+        .with_user_agent("bad\nagent")
+        .with_timeout(Duration::from_secs(10));
+    let client = FccClient::new(config).expect("client construction should not fail");
+
+    let zip_content = create_test_zip(b"data");
+    Mock::given(method("GET"))
+        .and(path("/complete/l_amat.zip"))
+        .and(header(
+            "user-agent",
+            uls_download::config::DEFAULT_USER_AGENT,
+        ))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_content.clone())
+                .insert_header("Content-Length", zip_content.len().to_string()),
+        )
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let file = ServiceCatalog::complete_license("amat").unwrap();
+    let (path, result) = client.download_file(&file, noop()).await.unwrap();
+    assert_eq!(result, DownloadResult::Downloaded);
+    assert_eq!(std::fs::read(&path).unwrap(), zip_content);
+}
+
+#[tokio::test]
+async fn test_unknown_service_resolution_errors_before_network() {
+    let temp_dir = TempDir::new().unwrap();
+    // Pointed at an unroutable address: the UnknownService error must precede any
+    // attempt to reach it, so the call returns without a network failure.
+    let client = create_test_client(temp_dir.path(), "http://localhost:1");
+
+    let err = client.download_complete("zzz").await.unwrap_err();
+    assert!(matches!(err, DownloadError::UnknownService(_)));
+}

--- a/crates/uls-parser/src/dat.rs
+++ b/crates/uls-parser/src/dat.rs
@@ -349,4 +349,260 @@ mod tests {
         assert!(!is_valid_record_type("License"));
         assert!(!is_valid_record_type(""));
     }
+
+    #[test]
+    fn test_from_line_empty_string_is_single_empty_field() {
+        // splitting "" on '|' yields one empty field, never an empty Vec,
+        // so from_line succeeds with an empty record type.
+        let parsed = ParsedLine::from_line("", 7).unwrap();
+        assert_eq!(parsed.line_number, 7);
+        assert_eq!(parsed.record_type, "");
+        assert_eq!(parsed.fields, vec![String::new()]);
+    }
+
+    #[test]
+    fn test_from_line_trailing_pipe_yields_trailing_empty_field() {
+        let parsed = ParsedLine::from_line("HD|123|W1AW|", 1).unwrap();
+        assert_eq!(
+            parsed.fields,
+            vec![
+                "HD".to_string(),
+                "123".to_string(),
+                "W1AW".to_string(),
+                String::new(),
+            ]
+        );
+        assert_eq!(parsed.field(3), "");
+    }
+
+    #[test]
+    fn test_from_line_embedded_empty_fields() {
+        let parsed = ParsedLine::from_line("EN|1||W1AW||John", 1).unwrap();
+        assert_eq!(parsed.fields.len(), 6);
+        assert_eq!(parsed.field(0), "EN");
+        assert_eq!(parsed.field(1), "1");
+        assert_eq!(parsed.field(2), "");
+        assert_eq!(parsed.field(3), "W1AW");
+        assert_eq!(parsed.field(4), "");
+        assert_eq!(parsed.field(5), "John");
+    }
+
+    #[test]
+    fn test_field_out_of_bounds_returns_empty() {
+        let parsed = ParsedLine::from_line("AM|1|W1AW", 1).unwrap();
+        assert_eq!(parsed.field(2), "W1AW");
+        assert_eq!(parsed.field(3), "");
+        assert_eq!(parsed.field(999), "");
+    }
+
+    #[test]
+    fn test_field_refs_mirrors_fields() {
+        let parsed = ParsedLine::from_line("HD|1||W1AW", 1).unwrap();
+        assert_eq!(parsed.field_refs(), vec!["HD", "1", "", "W1AW"]);
+    }
+
+    #[test]
+    fn test_parse_line_matches_from_line() {
+        let parsed = parse_line("CO|42|note", 99).unwrap();
+        assert_eq!(parsed.line_number, 99);
+        assert_eq!(parsed.record_type, "CO");
+        assert_eq!(parsed.field(2), "note");
+    }
+
+    #[test]
+    fn test_to_record_known_type_header() {
+        let parsed = ParsedLine::from_line("HD|123456789|||W1AW|A|HA", 1).unwrap();
+        let record = parsed.to_record().unwrap();
+        match record {
+            UlsRecord::Header(h) => {
+                assert_eq!(h.unique_system_identifier, 123456789);
+                assert_eq!(h.call_sign, Some("W1AW".to_string()));
+            }
+            other => panic!("expected Header, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_to_record_amateur_type() {
+        let parsed = ParsedLine::from_line("AM|254305|||KK9HIU|E|A|8", 1).unwrap();
+        let record = parsed.to_record().unwrap();
+        match record {
+            UlsRecord::Amateur(a) => {
+                assert_eq!(a.unique_system_identifier, 254305);
+                assert_eq!(a.callsign, Some("KK9HIU".to_string()));
+                assert_eq!(a.operator_class, Some('E'));
+                assert_eq!(a.region_code, Some(8));
+            }
+            other => panic!("expected Amateur, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_to_record_valid_recordtype_but_unmapped_is_raw() {
+        // LA parses as a RecordType but has no explicit arm in to_record_from_refs,
+        // so it falls through to the Raw branch carrying every field.
+        let parsed = ParsedLine::from_line("LA|780866|W1AW|L|Pleading", 1).unwrap();
+        let record = parsed.to_record().unwrap();
+        match record {
+            UlsRecord::Raw {
+                record_type,
+                fields,
+            } => {
+                assert_eq!(record_type, RecordType::LA);
+                assert_eq!(fields, vec!["LA", "780866", "W1AW", "L", "Pleading"]);
+            }
+            other => panic!("expected Raw, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_to_record_unknown_type_errors() {
+        // ZZ is two uppercase letters but is not a known RecordType,
+        // so to_record returns UnknownRecordType.
+        let parsed = ParsedLine::from_line("ZZ|1|2", 1).unwrap();
+        let err = parsed.to_record().unwrap_err();
+        match err {
+            ParseError::UnknownRecordType(rt) => assert_eq!(rt, "ZZ"),
+            other => panic!("expected UnknownRecordType, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_to_record_large_record_heap_path() {
+        // More than STACK_LIMIT (64) fields forces the heap fallback in to_record.
+        let mut parts = vec!["HD".to_string(), "999".to_string()];
+        parts.resize(80, "x".to_string());
+        let line = parts.join("|");
+        let parsed = ParsedLine::from_line(&line, 1).unwrap();
+        assert_eq!(parsed.fields.len(), 80);
+        let record = parsed.to_record().unwrap();
+        match record {
+            UlsRecord::Header(h) => assert_eq!(h.unique_system_identifier, 999),
+            other => panic!("expected Header, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_append_continuation_to_last_nonempty_field() {
+        let mut parsed = ParsedLine::from_line("CO|1||W1AW|First line||", 1).unwrap();
+        parsed.append_continuation("second line");
+        assert_eq!(parsed.field(4), "First line second line");
+    }
+
+    #[test]
+    fn test_append_continuation_strips_pipes_and_trims() {
+        let mut parsed = ParsedLine::from_line("CO|1||W1AW|First", 1).unwrap();
+        parsed.append_continuation("|  more text  |");
+        assert_eq!(parsed.field(4), "First more text");
+    }
+
+    #[test]
+    fn test_append_continuation_no_separator_when_target_empty() {
+        // Trailing empty fields are skipped; with no non-empty content the
+        // continuation lands on field 0 without a leading separator space.
+        let mut parsed = ParsedLine::from_line("||", 1).unwrap();
+        parsed.append_continuation("orphan");
+        assert_eq!(parsed.field(0), "orphan");
+    }
+
+    #[test]
+    fn test_reader_skips_blank_lines_between_records() {
+        let data = "HD|1||W1AW|A|HA\n\nHD|2||W2AW|A|HA\n";
+        let reader = DatReader::new(data.as_bytes());
+        let records: Vec<_> = reader.map(|r| r.unwrap()).collect();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].field(3), "W1AW");
+        assert_eq!(records[1].field(3), "W2AW");
+    }
+
+    #[test]
+    fn test_reader_handles_crlf_line_endings() {
+        let data = "HD|1||W1AW|A|HA\r\nHD|2||W2AW|A|HA\r\n";
+        let reader = DatReader::new(data.as_bytes());
+        let records: Vec<_> = reader.map(|r| r.unwrap()).collect();
+        assert_eq!(records.len(), 2);
+        // The trailing carriage return is stripped from the final field.
+        assert_eq!(records[0].record_type, "HD");
+        assert_eq!(records[1].field(3), "W2AW");
+        assert_eq!(records[1].field(5), "HA");
+    }
+
+    #[test]
+    fn test_reader_orphan_continuation_at_start_is_skipped() {
+        // A continuation line with no preceding record is dropped.
+        let data = "orphan continuation\nHD|1||W1AW|A|HA\n";
+        let reader = DatReader::new(data.as_bytes());
+        let records: Vec<_> = reader.map(|r| r.unwrap()).collect();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].record_type, "HD");
+    }
+
+    #[test]
+    fn test_reader_returns_final_pending_record_at_eof() {
+        // A single record with no trailing newline is still yielded.
+        let data = "HD|1||W1AW|A|HA";
+        let reader = DatReader::new(data.as_bytes());
+        let records: Vec<_> = reader.map(|r| r.unwrap()).collect();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].field(3), "W1AW");
+    }
+
+    #[test]
+    fn test_reader_line_number_tracks_raw_lines() {
+        let data = "HD|1||W1AW|desc\ncontinuation\nHD|2||W2AW|desc2\n";
+        let mut reader = DatReader::new(data.as_bytes());
+        assert_eq!(reader.line_number(), 0);
+        let first = reader.next_line().unwrap().unwrap();
+        // First record is emitted only once the second HD is read on line 3,
+        // with the line-2 continuation merged into its last description field.
+        assert_eq!(first.field(3), "W1AW");
+        assert_eq!(first.field(4), "desc continuation");
+        assert_eq!(reader.line_number(), 3);
+        let second = reader.next_line().unwrap().unwrap();
+        assert_eq!(second.field(3), "W2AW");
+        assert!(reader.next_line().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_open_nonexistent_file_errors() {
+        match DatReader::<File>::open("/no/such/path/missing.dat") {
+            Err(ParseError::Io(_)) => {}
+            Err(other) => panic!("expected Io error, got {other:?}"),
+            Ok(_) => panic!("expected error opening missing path"),
+        }
+    }
+
+    #[test]
+    fn test_parse_file_round_trip_from_temp() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("HD.dat");
+        let mut f = File::create(&path).unwrap();
+        f.write_all(b"HD|111||W1AW|A|HA\nHD|222||W2AW|A|HA\n")
+            .unwrap();
+        drop(f);
+
+        let records = parse_file(&path).unwrap();
+        assert_eq!(records.len(), 2);
+        match &records[0] {
+            UlsRecord::Header(h) => assert_eq!(h.unique_system_identifier, 111),
+            other => panic!("expected Header, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_file_propagates_unknown_record_error() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.dat");
+        let mut f = File::create(&path).unwrap();
+        // CH is in VALID_RECORD_TYPES, so the reader treats it as a record start
+        // rather than a continuation, yet it fails RecordType parsing, so
+        // parse_file surfaces UnknownRecordType.
+        f.write_all(b"CH|1|2\n").unwrap();
+        drop(f);
+
+        let err = parse_file(&path).unwrap_err();
+        assert!(matches!(err, ParseError::UnknownRecordType(rt) if rt == "CH"));
+    }
 }

--- a/crates/uls-parser/tests/archive_fixtures.rs
+++ b/crates/uls-parser/tests/archive_fixtures.rs
@@ -1,0 +1,259 @@
+//! Integration tests for ZipExtractor over file-backed archives.
+//!
+//! These exercise the public `open` path against ZIPs built from the shared
+//! fixture .dat files, plus error paths for missing and corrupt archives.
+
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::PathBuf;
+
+use tempfile::TempDir;
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+use uls_parser::archive::{ArchiveStats, ZipError};
+use uls_parser::ParseError;
+use uls_parser::ZipExtractor;
+
+/// Path to the shared fixture directory at the workspace root.
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("tests/fixtures/fcc-sample")
+}
+
+/// Build a ZIP from every .dat file in a fixture service directory.
+fn create_fixture_zip(temp_dir: &TempDir, service: &str) -> PathBuf {
+    let fixture_dir = fixture_path().join(service);
+    let zip_path = temp_dir.path().join(format!("{service}.zip"));
+
+    let file = File::create(&zip_path).unwrap();
+    let mut zip = ZipWriter::new(file);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+
+    for entry in fs::read_dir(&fixture_dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "dat") {
+            let filename = path.file_name().unwrap().to_str().unwrap();
+            let contents = fs::read(&path).unwrap();
+            zip.start_file(filename, options).unwrap();
+            zip.write_all(&contents).unwrap();
+        }
+    }
+
+    zip.finish().unwrap();
+    zip_path
+}
+
+/// Count records in a fixture .dat file the way the parser does: each non-empty
+/// line whose first field parses as a known FCC record type begins a record
+/// (continuation lines fold into it). Cross-checks count_all_records using the
+/// uls-core RecordType enum rather than a hand-maintained type list.
+fn expected_record_count(service: &str, dat: &str) -> usize {
+    use std::io::{BufRead, BufReader};
+    let path = fixture_path().join(service).join(dat);
+    let file = File::open(path).unwrap();
+    let reader = BufReader::new(file);
+    let mut count = 0;
+    for line in reader.lines().map_while(Result::ok) {
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            continue;
+        }
+        let first = trimmed.split('|').next().unwrap_or("");
+        if first.parse::<uls_core::codes::RecordType>().is_ok() {
+            count += 1;
+        }
+    }
+    count
+}
+
+#[test]
+fn test_open_fixture_zip_lists_dat_files() {
+    let temp = TempDir::new().unwrap();
+    let zip_path = create_fixture_zip(&temp, "l_amat");
+
+    let mut extractor = ZipExtractor::open(&zip_path).unwrap();
+    let mut dat_files = extractor.list_dat_files();
+    dat_files.sort();
+
+    assert_eq!(
+        dat_files,
+        vec!["AM.dat", "CO.dat", "EN.dat", "HD.dat", "HS.dat", "LA.dat", "SC.dat",]
+    );
+}
+
+#[test]
+fn test_open_nonexistent_path_errors_io() {
+    let result = ZipExtractor::open("/no/such/path/missing.zip");
+    match result {
+        Err(ZipError::Io(_)) => {}
+        Err(other) => panic!("expected Io error, got {other:?}"),
+        Ok(_) => panic!("expected error opening missing zip"),
+    }
+}
+
+#[test]
+fn test_open_non_zip_file_errors_zip() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("not-a-zip.zip");
+    let mut f = File::create(&path).unwrap();
+    f.write_all(b"this is plainly not a zip archive at all")
+        .unwrap();
+    drop(f);
+
+    let result = ZipExtractor::open(&path);
+    match result {
+        Err(ZipError::Zip(_)) => {}
+        Err(other) => panic!("expected Zip error, got {other:?}"),
+        Ok(_) => panic!("expected error opening non-zip file"),
+    }
+}
+
+#[test]
+fn test_open_truncated_zip_errors_zip() {
+    let temp = TempDir::new().unwrap();
+    let good = create_fixture_zip(&temp, "l_amat");
+    let bytes = fs::read(&good).unwrap();
+
+    // Keep only the leading half so the central directory is gone.
+    let truncated_path = temp.path().join("truncated.zip");
+    let mut f = File::create(&truncated_path).unwrap();
+    f.write_all(&bytes[..bytes.len() / 2]).unwrap();
+    drop(f);
+
+    let result = ZipExtractor::open(&truncated_path);
+    assert!(
+        matches!(result, Err(ZipError::Zip(_))),
+        "truncated archive should be a Zip error"
+    );
+}
+
+#[test]
+fn test_stats_reports_counts_and_nonzero_size() {
+    let temp = TempDir::new().unwrap();
+    let zip_path = create_fixture_zip(&temp, "l_amat");
+    let mut extractor = ZipExtractor::open(&zip_path).unwrap();
+
+    let ArchiveStats {
+        total_files,
+        dat_files,
+        total_size_bytes,
+    } = extractor.stats().unwrap();
+
+    // The l_amat fixture has seven .dat files and nothing else.
+    assert_eq!(total_files, 7);
+    assert_eq!(dat_files.len(), 7);
+    assert!(total_size_bytes > 0);
+
+    // total_size_bytes is the sum of each entry's uncompressed size.
+    let expected_total: u64 = dat_files
+        .iter()
+        .map(|name| extractor.file_size(name).unwrap())
+        .sum();
+    assert_eq!(total_size_bytes, expected_total);
+}
+
+#[test]
+fn test_count_all_records_matches_fixture_lines() {
+    let temp = TempDir::new().unwrap();
+    let zip_path = create_fixture_zip(&temp, "l_amat");
+    let mut extractor = ZipExtractor::open(&zip_path).unwrap();
+
+    let counts = extractor.count_all_records().unwrap();
+    assert_eq!(counts.len(), 7);
+
+    for (dat, count) in &counts {
+        assert_eq!(
+            *count,
+            expected_record_count("l_amat", dat),
+            "record count mismatch for {dat}"
+        );
+    }
+
+    assert_eq!(counts["HD.dat"], 34);
+    assert_eq!(counts["AM.dat"], 34);
+    assert_eq!(counts["LA.dat"], 1);
+}
+
+#[test]
+fn test_count_all_records_gmrs_fixture() {
+    let temp = TempDir::new().unwrap();
+    let zip_path = create_fixture_zip(&temp, "l_gmrs");
+    let mut extractor = ZipExtractor::open(&zip_path).unwrap();
+
+    let counts = extractor.count_all_records().unwrap();
+    assert_eq!(counts["HD.dat"], 33);
+    assert_eq!(counts["EN.dat"], 33);
+}
+
+#[test]
+fn test_file_size_matches_uncompressed_fixture_bytes() {
+    let temp = TempDir::new().unwrap();
+    let zip_path = create_fixture_zip(&temp, "l_amat");
+    let mut extractor = ZipExtractor::open(&zip_path).unwrap();
+
+    let on_disk = fs::metadata(fixture_path().join("l_amat").join("HD.dat"))
+        .unwrap()
+        .len();
+    assert_eq!(extractor.file_size("HD.dat").unwrap(), on_disk);
+}
+
+#[test]
+fn test_process_dat_streaming_visits_every_record() {
+    let temp = TempDir::new().unwrap();
+    let zip_path = create_fixture_zip(&temp, "l_amat");
+    let mut extractor = ZipExtractor::open(&zip_path).unwrap();
+
+    let mut callsigns = Vec::new();
+    let count = extractor
+        .process_dat_streaming("HD.dat", |line| {
+            assert_eq!(line.record_type, "HD");
+            callsigns.push(line.field(4).to_string());
+            true
+        })
+        .unwrap();
+
+    assert_eq!(count, 34);
+    assert_eq!(callsigns.len(), 34);
+    assert!(callsigns.iter().all(|c| !c.is_empty()));
+}
+
+#[test]
+fn test_process_dat_streaming_missing_file_is_parse_error() {
+    let temp = TempDir::new().unwrap();
+    let zip_path = create_fixture_zip(&temp, "l_amat");
+    let mut extractor = ZipExtractor::open(&zip_path).unwrap();
+
+    let result = extractor.process_dat_streaming("DOES_NOT_EXIST.dat", |_| true);
+    match result {
+        Err(ParseError::InvalidFormat { line, message }) => {
+            assert_eq!(line, 0);
+            assert!(message.contains("DOES_NOT_EXIST.dat"));
+        }
+        other => panic!("expected InvalidFormat parse error, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_get_file_creation_date_counts_without_date_line() {
+    let temp = TempDir::new().unwrap();
+    let zip_path = temp.path().join("counts-no-date.zip");
+
+    {
+        let file = File::create(&zip_path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        zip.start_file("counts", options).unwrap();
+        zip.write_all(b"  1234 /some/path/AM.dat\n  5678 /some/path/HD.dat\n")
+            .unwrap();
+        zip.finish().unwrap();
+    }
+
+    let mut extractor = ZipExtractor::open(&zip_path).unwrap();
+    assert!(extractor.get_file_creation_date().is_none());
+}

--- a/crates/uls-query/src/engine.rs
+++ b/crates/uls-query/src/engine.rs
@@ -408,4 +408,165 @@ mod tests {
         assert!(missing.contains(&"EN".to_string()));
         assert!(missing.contains(&"AM".to_string()));
     }
+
+    #[test]
+    fn test_open_uninitialized_db_returns_not_initialized() {
+        // A file-backed database that has never had its schema applied reports
+        // NotInitialized when opened through the query engine.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.db");
+
+        // Touch the file via with_config so it exists but lacks schema.
+        let db = Database::with_config(DatabaseConfig::with_path(&path)).unwrap();
+        assert!(!db.is_initialized().unwrap());
+        drop(db);
+
+        match QueryEngine::open(&path) {
+            Err(QueryError::NotInitialized) => {}
+            Err(other) => panic!("expected NotInitialized, got {other}"),
+            Ok(_) => panic!("expected NotInitialized error, got an engine"),
+        }
+
+        // The error renders the operator-facing guidance.
+        let err = QueryError::NotInitialized;
+        assert_eq!(
+            err.to_string(),
+            "database not initialized - run 'uls update' first"
+        );
+    }
+
+    #[test]
+    fn test_open_initialized_db_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ready.db");
+
+        // Initialize the schema, then drop the handle.
+        let db = Database::with_config(DatabaseConfig::with_path(&path)).unwrap();
+        db.initialize().unwrap();
+        drop(db);
+
+        // Opening the same path yields a ready engine.
+        let engine = QueryEngine::open(&path).unwrap();
+        assert!(engine.is_ready().unwrap());
+        let stats = engine.stats().unwrap();
+        assert_eq!(stats.total_licenses, 0);
+    }
+
+    #[test]
+    fn test_search_operator_class_join_returns_class() {
+        use uls_core::records::{AmateurRecord, HeaderRecord, UlsRecord};
+
+        let config = DatabaseConfig::in_memory();
+        let db = Database::with_config(config).unwrap();
+        db.initialize().unwrap();
+
+        // Header for the license.
+        let mut header = HeaderRecord::from_fields(&["HD", "555"]);
+        header.unique_system_identifier = 555;
+        header.call_sign = Some("W1EXT".to_string());
+        header.license_status = Some('A');
+        header.radio_service_code = Some("HA".to_string());
+        db.insert_record(&UlsRecord::Header(header)).unwrap();
+
+        // Amateur record carrying the Extra operator class.
+        let amateur = AmateurRecord {
+            unique_system_identifier: 555,
+            operator_class: Some('E'),
+            ..AmateurRecord::from_fields(&["AM", "555"])
+        };
+        db.insert_record(&UlsRecord::Amateur(amateur)).unwrap();
+
+        let engine = QueryEngine::with_database(db);
+
+        // Filtering by operator class exercises the amateur_operators join.
+        let filter = SearchFilter::callsign("W1EXT").with_operator_class('E');
+        let results = engine.search(filter).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].operator_class, Some('E'));
+
+        // A different class must not match the joined row.
+        let filter = SearchFilter::callsign("W1EXT").with_operator_class('T');
+        assert!(engine.search(filter).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_search_orders_and_limits_multiple_rows() {
+        use uls_core::records::{HeaderRecord, UlsRecord};
+
+        let config = DatabaseConfig::in_memory();
+        let db = Database::with_config(config).unwrap();
+        db.initialize().unwrap();
+
+        for (id, call) in [(1_i64, "W3CCC"), (2, "W1AAA"), (3, "W2BBB")] {
+            let mut header = HeaderRecord::from_fields(&["HD", "0"]);
+            header.unique_system_identifier = id;
+            header.call_sign = Some(call.to_string());
+            header.license_status = Some('A');
+            header.radio_service_code = Some("HA".to_string());
+            db.insert_record(&UlsRecord::Header(header)).unwrap();
+        }
+
+        let engine = QueryEngine::with_database(db);
+
+        // Default callsign-ascending sort across all rows.
+        let all = engine.search(SearchFilter::default()).unwrap();
+        let calls: Vec<&str> = all.iter().map(|l| l.call_sign.as_str()).collect();
+        assert_eq!(calls, vec!["W1AAA", "W2BBB", "W3CCC"]);
+
+        // Descending sort with a limit returns the top single row only.
+        let filter = SearchFilter::default()
+            .with_sort(crate::filter::SortOrder::CallSignDesc)
+            .with_limit(1);
+        let top = engine.search(filter).unwrap();
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].call_sign, "W3CCC");
+
+        // Count ignores limit and reflects the full match set.
+        assert_eq!(engine.count(SearchFilter::default()).unwrap(), 3);
+    }
+
+    #[test]
+    fn test_lookup_and_lookup_by_frn_return_populated_license() {
+        use uls_core::records::{EntityRecord, HeaderRecord, UlsRecord};
+
+        let config = DatabaseConfig::in_memory();
+        let db = Database::with_config(config).unwrap();
+        db.initialize().unwrap();
+
+        let mut header = HeaderRecord::from_fields(&["HD", "777"]);
+        header.unique_system_identifier = 777;
+        header.call_sign = Some("W1ABC".to_string());
+        header.license_status = Some('A');
+        header.radio_service_code = Some("HA".to_string());
+        db.insert_record(&UlsRecord::Header(header)).unwrap();
+
+        let entity = EntityRecord {
+            unique_system_identifier: 777,
+            call_sign: Some("W1ABC".to_string()),
+            entity_name: Some("Jane Operator".to_string()),
+            frn: Some("0009876543".to_string()),
+            city: Some("NEWINGTON".to_string()),
+            state: Some("CT".to_string()),
+            ..EntityRecord::from_fields(&["EN", "777"])
+        };
+        db.insert_record(&UlsRecord::Entity(entity)).unwrap();
+
+        let engine = QueryEngine::with_database(db);
+
+        // Callsign lookup is case-insensitive and returns the joined entity data.
+        let found = engine.lookup("w1abc").unwrap().expect("license present");
+        assert_eq!(found.call_sign, "W1ABC");
+        assert_eq!(found.frn.as_deref(), Some("0009876543"));
+        assert_eq!(found.licensee_name, "Jane Operator");
+        assert_eq!(found.city.as_deref(), Some("NEWINGTON"));
+
+        // FRN lookup resolves the same license via the entities inner join.
+        let by_frn = engine.lookup_by_frn("0009876543").unwrap();
+        assert_eq!(by_frn.len(), 1);
+        assert_eq!(by_frn[0].call_sign, "W1ABC");
+        assert_eq!(by_frn[0].unique_system_identifier, 777);
+
+        // A non-matching FRN yields no rows.
+        assert!(engine.lookup_by_frn("0000000000").unwrap().is_empty());
+    }
 }

--- a/crates/uls-query/src/filter.rs
+++ b/crates/uls-query/src/filter.rs
@@ -821,4 +821,152 @@ mod tests {
         // Falls back to original string since parse failed
         assert!(params.contains(&"UNKNOWN".to_string()));
     }
+
+    #[test]
+    fn test_default_filter_is_empty() {
+        // The derived Default and new() must agree and produce no conditions.
+        let from_default = SearchFilter::default();
+        let from_new = SearchFilter::new();
+
+        assert_eq!(from_default.to_where_clause(), from_new.to_where_clause());
+        assert_eq!(from_default.to_where_clause().0, "1=1");
+        assert_eq!(from_default.order_clause(), "ORDER BY l.call_sign ASC");
+        assert_eq!(from_default.limit_clause(), "");
+        assert_eq!(from_default.sort, SortOrder::CallSign);
+        assert!(!from_default.active_only);
+        assert!(from_default.callsign.is_none());
+    }
+
+    #[test]
+    fn test_convert_enum_value_class() {
+        // class field maps the operator-class char to its integer code.
+        let converted = convert_enum_value("class", "E");
+        assert_eq!(converted, Some(OperatorClass::Extra.to_u8().to_string()));
+
+        // The operator_class alias resolves the same way.
+        assert_eq!(
+            convert_enum_value("operator_class", "E"),
+            Some(OperatorClass::Extra.to_u8().to_string())
+        );
+
+        // An unparseable class char yields None (no conversion).
+        assert_eq!(convert_enum_value("class", "Z"), None);
+    }
+
+    #[test]
+    fn test_convert_enum_value_service() {
+        // service field maps the radio-service code to its integer code.
+        assert_eq!(
+            convert_enum_value("service", "HA"),
+            Some(RadioService::HA.to_u8().to_string())
+        );
+        assert_eq!(
+            convert_enum_value("radio_service", "HV"),
+            Some(RadioService::HV.to_u8().to_string())
+        );
+
+        // An unparseable service code yields None.
+        assert_eq!(convert_enum_value("service", "ZZ"), None);
+    }
+
+    #[test]
+    fn test_convert_enum_value_non_enum_field() {
+        // A non-enum field is never converted.
+        assert_eq!(convert_enum_value("call_sign", "W1AW"), None);
+    }
+
+    #[test]
+    fn test_generic_filter_class_enum_conversion() {
+        // class=E goes through convert_enum_value and stores the integer code.
+        let filter = SearchFilter::new().with_filter("class=E");
+        let (clause, params) = filter.to_where_clause();
+
+        assert!(clause.contains("a.operator_class"));
+        assert!(params.contains(&OperatorClass::Extra.to_u8().to_string()));
+    }
+
+    #[test]
+    fn test_generic_filter_service_enum_conversion() {
+        // service=HA goes through convert_enum_value and stores the integer code.
+        let filter = SearchFilter::new().with_filter("service=HA");
+        let (clause, params) = filter.to_where_clause();
+
+        assert!(clause.contains("l.radio_service_code"));
+        assert!(params.contains(&RadioService::HA.to_u8().to_string()));
+    }
+
+    #[test]
+    fn test_active_only_without_status_inlines_code() {
+        // Setting active_only directly (with status unset) emits an inline code
+        // comparison rather than a bound parameter.
+        let mut filter = SearchFilter::new();
+        filter.active_only = true;
+        let (clause, params) = filter.to_where_clause();
+
+        let active_code = LicenseStatus::Active.to_u8();
+        assert!(clause.contains(&format!("l.license_status = {}", active_code)));
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_status_takes_precedence_over_active_only() {
+        // When both status and active_only are set, status wins and binds a param.
+        let mut filter = SearchFilter::new();
+        filter.status = Some('E');
+        filter.active_only = true;
+        let (clause, params) = filter.to_where_clause();
+
+        // Parameterized status comparison, not the inline active_only code.
+        assert!(clause.contains("l.license_status = ?"));
+        let expired_code = LicenseStatus::Expired.to_u8().to_string();
+        assert!(params.contains(&expired_code));
+        assert!(!clause.contains(&format!(
+            "l.license_status = {}",
+            LicenseStatus::Active.to_u8()
+        )));
+    }
+
+    #[test]
+    fn test_invalid_operator_class_char_skipped() {
+        // An unparseable operator_class char produces no condition at all.
+        let mut filter = SearchFilter::new();
+        filter.operator_class = Some('Z');
+        let (clause, params) = filter.to_where_clause();
+
+        assert_eq!(clause, "1=1");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_generic_filter_invalid_op_for_char_field_skipped() {
+        // class is a Char field; the > operator is invalid for it, so the
+        // expression is dropped and no condition is emitted.
+        let filter = SearchFilter::new().with_filter("class>E");
+        let (clause, params) = filter.to_where_clause();
+
+        assert_eq!(clause, "1=1");
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_order_clause_generic_field_descending() {
+        // A registered sort field with the descending prefix maps to its column.
+        let filter = SearchFilter::new().with_sort_field("-grant_date");
+        assert_eq!(filter.order_clause(), "ORDER BY l.grant_date DESC");
+    }
+
+    #[test]
+    fn test_order_clause_generic_field_ascending() {
+        let filter = SearchFilter::new().with_sort_field("call_sign");
+        assert_eq!(filter.order_clause(), "ORDER BY l.call_sign ASC");
+    }
+
+    #[test]
+    fn test_order_clause_unknown_field_falls_back_to_legacy() {
+        // An unregistered sort_field falls through to the legacy SortOrder.
+        let mut filter = SearchFilter::new();
+        filter.sort_field = Some("not_a_field".to_string());
+        filter.sort = SortOrder::State;
+        assert_eq!(filter.order_clause(), "ORDER BY e.state ASC, e.city ASC");
+    }
 }

--- a/crates/uls-query/src/output.rs
+++ b/crates/uls-query/src/output.rs
@@ -632,6 +632,49 @@ mod tests {
     }
 
     #[test]
+    fn test_vec_table_no_operator_class_shows_dash() {
+        // A license with no operator class renders "-" in the CLASS column.
+        let mut license = test_license();
+        license.operator_class = None;
+        let output = vec![license].format(OutputFormat::Table);
+
+        // The data row pads the class column to width 5; the placeholder is "-".
+        let data_line = output
+            .lines()
+            .find(|l| l.contains("W1TEST"))
+            .expect("data row present");
+        assert!(
+            data_line.contains(" -    "),
+            "expected dash placeholder in class column: {:?}",
+            data_line
+        );
+    }
+
+    #[test]
+    fn test_vec_table_with_operator_class_shows_class() {
+        // A license with an operator class renders the class letter in the
+        // CLASS column, not a dash. test_license has operator_class Some('E').
+        let output = vec![test_license()].format(OutputFormat::Table);
+        let data_line = output
+            .lines()
+            .find(|l| l.contains("W1TEST"))
+            .expect("data row present");
+        // The CLASS column is {:<5} preceded by a separator space, so the
+        // populated slot is a space, the class letter, then four pad spaces.
+        // Matching the exact slot avoids passing on the 'E' in "NEWINGTON".
+        assert!(
+            data_line.contains(" E    "),
+            "expected class letter in class column slot: {:?}",
+            data_line
+        );
+        assert!(
+            !data_line.contains(" -    "),
+            "class column should not render the dash placeholder: {:?}",
+            data_line
+        );
+    }
+
+    #[test]
     fn test_output_format_aliases() {
         // Test alternative format names
         assert_eq!("yml".parse::<OutputFormat>(), Ok(OutputFormat::Yaml));


### PR DESCRIPTION
Add tests across all seven crates, increasing line coverage to ~95.9%.

Highlights:
- `uls-core`: exhaustive enum round-trips (to_u8/from_u8/Display/FromStr) and record from_fields edge cases
- `uls-db`: in-memory query/freshness/schema/importer tests + bulk-inserter encoding checks
- `uls-download`: wiremock client behavior (etag/304/retry/fallback), catalog, progress, config
- `uls-api`: error-to-status mapping and axum routing via oneshot
- `uls-cli`: update orchestration via a wiremock FccClient + temp DB, plus search/lookup/frn/staleness coverage
- `uls-parser`: dat parsing edge cases and file-backed ZIP extraction