### PR TITLE
ci: harden workflows per zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,17 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -39,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -70,6 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -95,6 +104,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -109,6 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -134,8 +147,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -174,6 +190,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
 
@@ -182,6 +200,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Remove toolchain pin so the MSRV toolchain is used
         run: rm -f rust-toolchain.toml
@@ -189,7 +209,6 @@ jobs:
       - name: Install Rust toolchain (MSRV)
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.88"
       
       - name: Check MSRV
         run: cargo check --all --locked

--- a/.github/workflows/fcc-monitor.yml
+++ b/.github/workflows/fcc-monitor.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 env:
   FCC_PUBLIC_ACCESS_URL: "https://www.fcc.gov/wireless/data/public-access-updates"
@@ -30,6 +29,8 @@ jobs:
       latest_update: ${{ steps.check-page.outputs.latest_update }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       
       - name: Check FCC Public Access Updates page
         id: check-page
@@ -134,6 +135,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 12 * * 0'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -176,6 +179,9 @@ jobs:
   notify-on-failure:
     name: Notify on Failure
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
     needs: [verify-data-availability]
     if: failure()
     steps:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,12 +22,17 @@ env:
   CARGO_TERM_COLOR: always
   FCC_DATA_BASE_URL: "https://data.fcc.gov/download/pub/uls"
 
+permissions:
+  contents: read
+
 jobs:
   integration-test:
     name: Integration Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -55,6 +60,8 @@ jobs:
     if: github.event.inputs.test_type == 'full' || github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -83,12 +90,14 @@ jobs:
       
       - name: Download and import amateur data
         run: |
-          if [[ "${{ github.event.inputs.force_download }}" == "true" ]]; then
+          if [[ "${GITHUB_EVENT_INPUTS_FORCE_DOWNLOAD}" == "true" ]]; then
             echo "Force download requested, clearing cache..."
             rm -rf ~/.cache/uls
           fi
           
           ./target/release/uls update --service amateur
+        env:
+          GITHUB_EVENT_INPUTS_FORCE_DOWNLOAD: ${{ github.event.inputs.force_download }}
       
       - name: Verify database stats
         run: |

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   release-plz-release:
     name: Release
@@ -47,6 +50,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@fe6ede73c7f0a50412ec05994e2aa5a7bf635eac # v1.0.7

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        dtolnay/rust-toolchain: ref-pin


### PR DESCRIPTION
- least-privilege `permissions:` blocks (scope fcc-monitor `issues: write` to its job)
- `persist-credentials: false` on checkouts
- fix template-injection in integration-test (input via env var)
- `.github/zizmor.yml` ref-pin policy for dtolnay/rust-toolchain (can't be hash-pinned)