### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5](https://github.com/tgies/uls/compare/v0.1.4...v0.1.5) - 2026-06-09
+
+### Added
+
+- *(cli)* add shell completion generation
+
+### Fixed
+
+- *(update)* resume daily chain after the Sunday daily on fresh weekly
+- *(update)* skip redundant daily download that coincides with weekly
+- *(cli)* use sort_by_key for license dedup sort
+- *(db)* close code span in operator_class doc comment
+- *(db)* scope weekly metadata query connection to avoid pool deadlock
+- *(download)* send versioned default User-Agent on invalid-config fallback
+
+### Other
+
+- *(cli)* add tests for cli commands, staleness warning, and update orchestration
+- *(update)* extract weekdays_to_check for direct test coverage
+- *(core)* add unit tests for record models and codes
+- *(deps)* bump criterion 0.5 -> 0.8
+- *(parser)* add dat parsing and zip archive integration tests
+- *(db)* add tests for bulk inserter, schema, importer, and queries
+- *(download)* add client behavior, catalog, and config tests
+- *(query)* add tests for engine, search filters, and output formatting
+- *(api)* add tests for error responses and routing endpoints
+
 ## [0.1.4](https://github.com/tgies/uls/compare/v0.1.3...v0.1.4) - 2026-03-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,7 +3062,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uls-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "axum",
  "chrono",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "uls-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "uls-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "proptest",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "uls-db"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "uls-download"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -3167,7 +3167,7 @@ dependencies = [
 
 [[package]]
 name = "uls-parser"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "criterion",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "uls-query"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,12 +79,12 @@ criterion = { version = "0.8", features = ["html_reports"] }
 gungraun = "0.19"
 
 # Workspace crates
-uls-core = { path = "crates/uls-core", version = "0.1.2" }
-uls-parser = { path = "crates/uls-parser", version = "0.1.2" }
-uls-db = { path = "crates/uls-db", version = "0.2.0" }
-uls-download = { path = "crates/uls-download", version = "0.2.1" }
-uls-api = { path = "crates/uls-api", version = "0.1.3" }
-uls-query = { path = "crates/uls-query", version = "0.1.3" }
+uls-core = { path = "crates/uls-core", version = "0.1.3" }
+uls-parser = { path = "crates/uls-parser", version = "0.1.3" }
+uls-db = { path = "crates/uls-db", version = "0.2.1" }
+uls-download = { path = "crates/uls-download", version = "0.2.2" }
+uls-api = { path = "crates/uls-api", version = "0.1.4" }
+uls-query = { path = "crates/uls-query", version = "0.1.4" }
 
 [profile.release]
 lto = true

--- a/crates/uls-api/Cargo.toml
+++ b/crates/uls-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-api"
 description = "REST API server for FCC ULS data access"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-cli/Cargo.toml
+++ b/crates/uls-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-cli"
 description = "CLI tool for FCC ULS data retrieval and management"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-core/Cargo.toml
+++ b/crates/uls-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-core"
 description = "Core data types and models for FCC ULS data"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-db/Cargo.toml
+++ b/crates/uls-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-db"
 description = "SQLite database layer for FCC ULS data storage"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-download/Cargo.toml
+++ b/crates/uls-download/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-download"
 description = "FCC ULS file download and synchronization"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-parser/Cargo.toml
+++ b/crates/uls-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-parser"
 description = "Parser for FCC ULS pipe-delimited DAT files"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-query/Cargo.toml
+++ b/crates/uls-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-query"
 description = "Query engine for FCC ULS data lookups"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `uls-core`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `uls-parser`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `uls-db`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `uls-query`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `uls-api`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `uls-download`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `uls-cli`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>







## `uls-cli`

<blockquote>

## [0.1.5](https://github.com/tgies/uls/compare/v0.1.4...v0.1.5) - 2026-06-09

### Added

- *(cli)* add shell completion generation

### Fixed

- *(update)* resume daily chain after the Sunday daily on fresh weekly
- *(update)* skip redundant daily download that coincides with weekly
- *(cli)* use sort_by_key for license dedup sort
- *(db)* close code span in operator_class doc comment
- *(db)* scope weekly metadata query connection to avoid pool deadlock
- *(download)* send versioned default User-Agent on invalid-config fallback

### Other

- *(cli)* add tests for cli commands, staleness warning, and update orchestration
- *(update)* extract weekdays_to_check for direct test coverage
- *(core)* add unit tests for record models and codes
- *(deps)* bump criterion 0.5 -> 0.8
- *(parser)* add dat parsing and zip archive integration tests
- *(db)* add tests for bulk inserter, schema, importer, and queries
- *(download)* add client behavior, catalog, and config tests
- *(query)* add tests for engine, search filters, and output formatting
- *(api)* add tests for error responses and routing endpoints
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).