### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6](https://github.com/tgies/uls/compare/v0.1.5...v0.1.6) - 2026-06-22
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.5](https://github.com/tgies/uls/compare/v0.1.4...v0.1.5) - 2026-06-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,7 +3078,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uls-api"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "axum",
  "chrono",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "uls-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ uls-core = { path = "crates/uls-core", version = "0.1.3" }
 uls-parser = { path = "crates/uls-parser", version = "0.1.3" }
 uls-db = { path = "crates/uls-db", version = "0.2.1" }
 uls-download = { path = "crates/uls-download", version = "0.2.2" }
-uls-api = { path = "crates/uls-api", version = "0.1.4" }
+uls-api = { path = "crates/uls-api", version = "0.1.5" }
 uls-query = { path = "crates/uls-query", version = "0.1.4" }
 
 [profile.release]

--- a/crates/uls-api/Cargo.toml
+++ b/crates/uls-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-api"
 description = "REST API server for FCC ULS data access"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-cli/Cargo.toml
+++ b/crates/uls-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-cli"
 description = "CLI tool for FCC ULS data retrieval and management"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `uls-api`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `uls-cli`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>


## `uls-cli`

<blockquote>

## [0.1.6](https://github.com/tgies/uls/compare/v0.1.5...v0.1.6) - 2026-06-22

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).