### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(update)* add exact update planning
-
-### Fixed
-
-- *(update)* expose pending bootstrap plans
-- *(update)* preserve contiguous daily progress
-- *(db)* roll back failed imports
-- *(query)* satisfy latest clippy
-
-### Other
-
-- *(update)* cover command orchestration
-
-### Added
-
-- *(update)* add machine-readable exact-date planning and bounded apply
+- *(update)* add machine-readable exact-date planning and bounded `--through` apply
 
 ### Fixed
 
@@ -34,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(update)* validate FCC archive dates and weekly coverage boundaries
 - *(update)* represent an unavailable bootstrap source as a valid empty plan
 - *(db)* roll back weekly and daily imports on parser or insert failure
+- *(query)* remain warning-free under the latest supported Clippy
+
+### Other
+
+- *(update)* add deterministic command-orchestration coverage
+
+### Security
+
+- *(deps)* update the vulnerable transitive `crossbeam-epoch` development dependency
 
 ## [0.1.6](https://github.com/tgies/uls/compare/v0.1.5...v0.1.6) - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/tgies/uls/compare/v0.1.6...v0.1.7) - 2026-07-24
+
+### Added
+
+- *(update)* add exact update planning
+
+### Fixed
+
+- *(update)* expose pending bootstrap plans
+- *(update)* preserve contiguous daily progress
+- *(db)* roll back failed imports
+- *(query)* satisfy latest clippy
+
+### Other
+
+- *(update)* cover command orchestration
+
 ### Added
 
 - *(update)* add machine-readable exact-date planning and bounded apply

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,7 +3078,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uls-api"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "axum",
  "chrono",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "uls-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "uls-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "proptest",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "uls-db"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "uls-download"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "uls-parser"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "criterion",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "uls-query"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,12 +79,12 @@ criterion = { version = "0.8", features = ["html_reports"] }
 gungraun = "0.19"
 
 # Workspace crates
-uls-core = { path = "crates/uls-core", version = "0.1.3" }
-uls-parser = { path = "crates/uls-parser", version = "0.1.3" }
-uls-db = { path = "crates/uls-db", version = "0.2.1" }
-uls-download = { path = "crates/uls-download", version = "0.2.2" }
-uls-api = { path = "crates/uls-api", version = "0.1.5" }
-uls-query = { path = "crates/uls-query", version = "0.1.4" }
+uls-core = { path = "crates/uls-core", version = "0.1.4" }
+uls-parser = { path = "crates/uls-parser", version = "0.1.4" }
+uls-db = { path = "crates/uls-db", version = "0.2.2" }
+uls-download = { path = "crates/uls-download", version = "0.2.3" }
+uls-api = { path = "crates/uls-api", version = "0.1.6" }
+uls-query = { path = "crates/uls-query", version = "0.1.5" }
 
 [profile.release]
 lto = true

--- a/crates/uls-api/Cargo.toml
+++ b/crates/uls-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-api"
 description = "REST API server for FCC ULS data access"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-cli/Cargo.toml
+++ b/crates/uls-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-cli"
 description = "CLI tool for FCC ULS data retrieval and management"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-core/Cargo.toml
+++ b/crates/uls-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-core"
 description = "Core data types and models for FCC ULS data"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-db/Cargo.toml
+++ b/crates/uls-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-db"
 description = "SQLite database layer for FCC ULS data storage"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-download/Cargo.toml
+++ b/crates/uls-download/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-download"
 description = "FCC ULS file download and synchronization"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-parser/Cargo.toml
+++ b/crates/uls-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-parser"
 description = "Parser for FCC ULS pipe-delimited DAT files"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/uls-query/Cargo.toml
+++ b/crates/uls-query/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uls-query"
 description = "Query engine for FCC ULS data lookups"
-version = "0.1.4"
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `uls-core`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `uls-parser`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `uls-db`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `uls-query`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `uls-api`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `uls-download`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `uls-cli`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>







## `uls-cli`

<blockquote>

## [0.1.7](https://github.com/tgies/uls/compare/v0.1.6...v0.1.7) - 2026-07-24

### Added

- *(update)* add exact update planning

### Fixed

- *(update)* expose pending bootstrap plans
- *(update)* preserve contiguous daily progress
- *(db)* roll back failed imports
- *(query)* satisfy latest clippy

### Other

- *(update)* cover command orchestration

### Added

- *(update)* add machine-readable exact-date planning and bounded apply

### Fixed

- *(update)* preserve the maximal contiguous daily prefix across later gaps
- *(update)* validate FCC archive dates and weekly coverage boundaries
- *(update)* represent an unavailable bootstrap source as a valid empty plan
- *(db)* roll back weekly and daily imports on parser or insert failure
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).