### PR TITLE
feat(update): support exact contiguous daily updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- *(update)* add machine-readable exact-date planning and bounded apply
+
+### Fixed
+
+- *(update)* preserve the maximal contiguous daily prefix across later gaps
+- *(update)* validate FCC archive dates and weekly coverage boundaries
+- *(db)* roll back weekly and daily imports on parser or insert failure
+
 ## [0.1.6](https://github.com/tgies/uls/compare/v0.1.5...v0.1.6) - 2026-06-22
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(update)* preserve the maximal contiguous daily prefix across later gaps
 - *(update)* validate FCC archive dates and weekly coverage boundaries
+- *(update)* represent an unavailable bootstrap source as a valid empty plan
 - *(db)* roll back weekly and daily imports on parser or insert failure
 
 ## [0.1.6](https://github.com/tgies/uls/compare/v0.1.5...v0.1.6) - 2026-06-22

--- a/README.md
+++ b/README.md
@@ -52,6 +52,31 @@ Additional FCC radio services are planned for future releases.
 | `uls download` | Download FCC files without building database |
 | `uls completions <SHELL>` | Generate shell completions (bash, zsh, fish, elvish, powershell) |
 
+### Safe update planning
+
+Automation can inspect the exact FCC source dates that are currently reachable
+without changing the database:
+
+```bash
+uls update --service amateur --plan --format json
+```
+
+The versioned `uls.update_plan` document includes the current weekly and source
+dates, every exactly reachable source date, the recommended date, observed FCC
+archive dates, and any gap in the current daily path. The reachable dates may be
+disjoint when a newer weekly snapshot safely bridges missing daily archives.
+
+After coordinating a common date across services, apply no farther than that
+date and require the database to reach it:
+
+```bash
+uls update --service amateur --through 2026-07-23 --format json
+```
+
+An unreachable target is rejected before database initialization or migration.
+Each imported archive is transactional. If a later archive fails, the command
+returns an error while retaining only the earlier, valid contiguous prefix.
+
 ## Configuration
 
 Environment variables:

--- a/crates/uls-cli/src/commands/update.rs
+++ b/crates/uls-cli/src/commands/update.rs
@@ -1964,6 +1964,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_plan_reports_pending_bootstrap_without_a_weekly() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(plan.document.current.weekly_date, None);
+        assert_eq!(plan.document.current.source_date, None);
+        assert!(plan.document.reachable_source_dates.is_empty());
+        assert_eq!(plan.document.recommended_source_date, None);
+        assert_eq!(plan.document.observed.weekly_date, None);
+        assert_eq!(
+            plan.document.observed.weekly_status,
+            planner::WeeklyObservationStatus::NotPublished
+        );
+        assert!(plan
+            .route_to(NaiveDate::from_ymd_opt(2026, 7, 23).unwrap())
+            .is_none());
+        assert!(db.get_last_weekly_date("HA").unwrap().is_none());
+        assert!(db.get_applied_patches("HA").unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn test_update_plan_rejects_noncontiguous_local_metadata() {
         let server = MockServer::start().await;
         let tmp = TempDir::new().unwrap();

--- a/crates/uls-cli/src/commands/update.rs
+++ b/crates/uls-cli/src/commands/update.rs
@@ -9,7 +9,9 @@ use chrono::{Datelike, NaiveDate, Utc};
 use indicatif::{ProgressBar, ProgressStyle};
 
 use uls_db::{Database, DatabaseConfig, ImportMode, Importer};
-use uls_download::{DownloadConfig, DownloadProgress, FccClient, ProgressCallback, ServiceCatalog};
+use uls_download::{
+    DownloadConfig, DownloadError, DownloadProgress, FccClient, ProgressCallback, ServiceCatalog,
+};
 use uls_parser::archive::ZipExtractor;
 
 use crate::config::{default_cache_path, default_db_path};
@@ -80,7 +82,11 @@ pub async fn execute_with_options(
 
     match result {
         UpdateResult::UpToDate => println!("\n✓ Database is up to date."),
-        UpdateResult::Updated { dailies, weekly } => {
+        UpdateResult::Updated {
+            dailies,
+            weekly,
+            gap,
+        } => {
             println!();
             if weekly {
                 println!("✓ Applied weekly import.");
@@ -88,19 +94,62 @@ pub async fn execute_with_options(
             if dailies > 0 {
                 println!("✓ Applied {} daily update(s).", dailies);
             }
+            if let Some(gap) = gap {
+                print_daily_gap(gap);
+            }
         }
-        UpdateResult::CheckOnly { available } => {
+        UpdateResult::Blocked { gap } => {
+            println!("\nDatabase was not changed.");
+            print_daily_gap(gap);
+        }
+        UpdateResult::CheckOnly { available, gap } => {
             println!("\n({} update(s) available, check mode)", available);
+            if let Some(gap) = gap {
+                print_daily_gap(gap);
+            }
         }
     }
 
     Ok(())
 }
 
+#[derive(Debug)]
 enum UpdateResult {
     UpToDate,
-    Updated { dailies: usize, weekly: bool },
-    CheckOnly { available: usize },
+    Updated {
+        dailies: usize,
+        weekly: bool,
+        gap: Option<DailyGap>,
+    },
+    Blocked {
+        gap: DailyGap,
+    },
+    CheckOnly {
+        available: usize,
+        gap: Option<DailyGap>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DailyGap {
+    missing_date: NaiveDate,
+    next_available_date: NaiveDate,
+}
+
+#[derive(Debug)]
+struct DailyChain {
+    contiguous: Vec<(NaiveDate, PathBuf)>,
+    gap: Option<DailyGap>,
+}
+
+fn print_daily_gap(gap: DailyGap) {
+    println!(
+        "⚠ Daily updates are incomplete: {} is missing before the next available archive ({}).",
+        gap.missing_date, gap.next_available_date
+    );
+    println!(
+        "  Later daily archives were not applied; a missing daily or newer weekly is required."
+    );
 }
 
 async fn run_update(
@@ -122,14 +171,29 @@ async fn run_update(
 
     // If no weekly in DB yet, we must import one
     if (db_weekly_date.is_none() || force) && !daily_only {
-        return apply_weekly_then_dailies(db, client, service_code, import_mode, today, check_only)
-            .await;
+        return apply_weekly_then_dailies(
+            db,
+            client,
+            service_code,
+            import_mode,
+            today,
+            check_only,
+            None,
+        )
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("unconditional weekly import was not applied"));
     }
 
     let weekly_date = db_weekly_date.unwrap_or(today);
+    let coverage_date = applied_patches
+        .iter()
+        .copied()
+        .filter(|date| *date > weekly_date)
+        .max()
+        .unwrap_or(weekly_date);
 
     // Try to build daily chain (no weekday to skip — we didn't just apply a weekly)
-    let chain_result = build_daily_chain(
+    let chain = build_daily_chain(
         client,
         service_code,
         weekly_date,
@@ -139,39 +203,64 @@ async fn run_update(
     )
     .await?;
 
-    match chain_result {
-        DailyChainResult::Complete(dailies) => {
-            if dailies.is_empty() {
-                return Ok(UpdateResult::UpToDate);
-            }
-            if check_only {
-                return Ok(UpdateResult::CheckOnly {
-                    available: dailies.len(),
-                });
-            }
-            let count = apply_dailies(db, service_code, import_mode, &dailies)?;
-            Ok(UpdateResult::Updated {
-                dailies: count,
-                weekly: false,
-            })
+    if !chain.contiguous.is_empty() {
+        if check_only {
+            return Ok(UpdateResult::CheckOnly {
+                available: chain.contiguous.len(),
+                gap: chain.gap,
+            });
         }
-        DailyChainResult::Broken { missing_date } => {
-            println!(
-                "Daily chain broken at {}. Falling back to weekly import.",
-                missing_date
-            );
-            if check_only {
-                return Ok(UpdateResult::CheckOnly { available: 1 });
-            }
-            apply_weekly_then_dailies(db, client, service_code, import_mode, today, check_only)
-                .await
-        }
+        // Persist independently useful prefix progress before attempting weekly
+        // recovery. If a gap remains, the next invocation evaluates the weekly
+        // path against the newly advanced coverage date.
+        let count = apply_dailies(db, service_code, import_mode, &chain.contiguous)?;
+        return Ok(UpdateResult::Updated {
+            dailies: count,
+            weekly: false,
+            gap: chain.gap,
+        });
     }
-}
 
-enum DailyChainResult {
-    Complete(Vec<(NaiveDate, PathBuf)>),
-    Broken { missing_date: NaiveDate },
+    let Some(gap) = chain.gap else {
+        return Ok(UpdateResult::UpToDate);
+    };
+
+    if daily_only {
+        return Ok(if check_only {
+            UpdateResult::CheckOnly {
+                available: 0,
+                gap: Some(gap),
+            }
+        } else {
+            UpdateResult::Blocked { gap }
+        });
+    }
+
+    println!(
+        "Daily chain is blocked at {}. Checking for a newer weekly import.",
+        gap.missing_date
+    );
+    if check_only {
+        return Ok(UpdateResult::CheckOnly {
+            available: 0,
+            gap: Some(gap),
+        });
+    }
+
+    match apply_weekly_then_dailies(
+        db,
+        client,
+        service_code,
+        import_mode,
+        today,
+        false,
+        Some(coverage_date),
+    )
+    .await?
+    {
+        Some(result) => Ok(result),
+        None => Ok(UpdateResult::Blocked { gap }),
+    }
 }
 
 /// Return the weekdays to check for daily files, optionally skipping the
@@ -193,15 +282,29 @@ fn weekdays_to_check(
         .collect()
 }
 
+fn weekly_covered_daily_weekday(weekly_date: NaiveDate) -> uls_download::catalog::Weekday {
+    let covered_data_date = weekly_date.pred_opt().unwrap_or(weekly_date);
+    uls_download::catalog::Weekday::for_date(covered_data_date)
+}
+
 async fn build_daily_chain(
     client: &FccClient,
     service_code: &str,
     last_update: NaiveDate,
     applied: &HashSet<NaiveDate>,
-    _today: NaiveDate,
+    today: NaiveDate,
     skip_weekday: Option<uls_download::catalog::Weekday>,
-) -> Result<DailyChainResult> {
+) -> Result<DailyChain> {
     let full_name = ServiceCatalog::full_name(service_code).unwrap_or("amat");
+    let chain_anchor = match contiguous_patch_coverage(last_update, applied) {
+        Ok(date) => date,
+        Err(gap) => {
+            return Ok(DailyChain {
+                contiguous: vec![],
+                gap: Some(gap),
+            });
+        }
+    };
 
     let mut available_dailies: Vec<(NaiveDate, PathBuf)> = vec![];
     let weekdays = weekdays_to_check(skip_weekday);
@@ -212,41 +315,92 @@ async fn build_daily_chain(
 
         match client.download_file(&data_file, progress).await {
             Ok((path, _)) => {
-                if let Ok(Some(canonical_date)) = extract_canonical_date(&path) {
-                    if canonical_date > last_update && !applied.contains(&canonical_date) {
-                        available_dailies.push((canonical_date, path));
-                    }
+                let canonical_date = extract_canonical_date(&path)?.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "daily archive {} has no valid FCC creation date",
+                        path.display()
+                    )
+                })?;
+                if canonical_date > today {
+                    bail!(
+                        "daily archive {} has future FCC creation date {} (today is {})",
+                        path.display(),
+                        canonical_date,
+                        today
+                    );
+                }
+                if canonical_date > chain_anchor {
+                    available_dailies.push((canonical_date, path));
                 }
             }
-            Err(_) => continue,
+            Err(DownloadError::NotFound { .. }) => tracing::debug!(
+                weekday = %weekday.abbrev(),
+                "daily archive is not published"
+            ),
+            Err(error) => return Err(error.into()),
         }
     }
 
     if available_dailies.is_empty() {
-        return Ok(DailyChainResult::Complete(vec![]));
+        return Ok(DailyChain {
+            contiguous: vec![],
+            gap: None,
+        });
     }
 
     // Sort by canonical date
     available_dailies.sort_by_key(|(date, _)| *date);
 
-    // Start from the latest applied patch after the weekly, not the weekly itself
-    let mut expected = applied
-        .iter()
-        .copied()
-        .filter(|d| *d > last_update)
-        .max()
-        .unwrap_or(last_update);
-    for (date, _) in &available_dailies {
-        let gap = (*date - expected).num_days();
-        if gap > 1 {
-            return Ok(DailyChainResult::Broken {
-                missing_date: expected.succ_opt().unwrap_or(expected),
+    let mut contiguous = Vec::new();
+    let mut expected = chain_anchor;
+    for (date, path) in available_dailies {
+        if date <= expected {
+            continue;
+        }
+        let next_expected = expected.succ_opt().unwrap_or(expected);
+        if date > next_expected {
+            return Ok(DailyChain {
+                contiguous,
+                gap: Some(DailyGap {
+                    missing_date: next_expected,
+                    next_available_date: date,
+                }),
             });
         }
-        expected = *date;
+        expected = date;
+        contiguous.push((date, path));
     }
 
-    Ok(DailyChainResult::Complete(available_dailies))
+    Ok(DailyChain {
+        contiguous,
+        gap: None,
+    })
+}
+
+fn contiguous_patch_coverage(
+    weekly_date: NaiveDate,
+    applied: &HashSet<NaiveDate>,
+) -> std::result::Result<NaiveDate, DailyGap> {
+    let mut dates: Vec<_> = applied
+        .iter()
+        .copied()
+        .filter(|date| *date > weekly_date)
+        .collect();
+    dates.sort_unstable();
+
+    let mut coverage_date = weekly_date;
+    for date in dates {
+        let expected = coverage_date.succ_opt().unwrap_or(coverage_date);
+        if date > expected {
+            return Err(DailyGap {
+                missing_date: expected,
+                next_available_date: date,
+            });
+        }
+        coverage_date = date;
+    }
+
+    Ok(coverage_date)
 }
 
 fn extract_canonical_date(zip_path: &PathBuf) -> Result<Option<NaiveDate>> {
@@ -292,33 +446,35 @@ async fn apply_weekly_then_dailies(
     import_mode: &ImportMode,
     today: NaiveDate,
     check_only: bool,
-) -> Result<UpdateResult> {
+    newer_than: Option<NaiveDate>,
+) -> Result<Option<UpdateResult>> {
     if check_only {
-        return Ok(UpdateResult::CheckOnly { available: 1 });
+        return Ok(Some(UpdateResult::CheckOnly {
+            available: 1,
+            gap: None,
+        }));
     }
 
-    let weekly_date = apply_weekly(db, client, service_code, import_mode).await?;
-
-    // A weekly created on date D covers through Sunday D and holds the same
-    // records as the Sunday daily, whose canonical (creation) date is D+1.
-    // Resume the chain from D+1: the Monday daily (canonical D+2) stays
-    // contiguous and the redundant Sunday daily is gated out. The weekday skip
-    // avoids downloading that Sunday daily.
-    let applied = HashSet::new();
-    let resume_from = weekly_date.succ_opt().unwrap_or(weekly_date);
-    let skip = Some(uls_download::catalog::Weekday::for_date(weekly_date));
-    let chain = build_daily_chain(client, service_code, resume_from, &applied, today, skip).await?;
-
-    let daily_count = if let DailyChainResult::Complete(dailies) = chain {
-        apply_dailies(db, service_code, import_mode, &dailies)?
-    } else {
-        0
+    let Some(weekly_date) =
+        apply_weekly(db, client, service_code, import_mode, newer_than, today).await?
+    else {
+        return Ok(None);
     };
 
-    Ok(UpdateResult::Updated {
+    // A weekly created on Sunday D includes data through Saturday and therefore
+    // subsumes the Saturday daily created on D. The Sunday daily is created on
+    // D+1 and remains the first required archive after the weekly.
+    let applied = HashSet::new();
+    let skip = Some(weekly_covered_daily_weekday(weekly_date));
+    let chain = build_daily_chain(client, service_code, weekly_date, &applied, today, skip).await?;
+
+    let daily_count = apply_dailies(db, service_code, import_mode, &chain.contiguous)?;
+
+    Ok(Some(UpdateResult::Updated {
         dailies: daily_count,
         weekly: true,
-    })
+        gap: chain.gap,
+    }))
 }
 
 async fn apply_weekly(
@@ -326,7 +482,9 @@ async fn apply_weekly(
     client: &FccClient,
     service_code: &str,
     import_mode: &ImportMode,
-) -> Result<NaiveDate> {
+    newer_than: Option<NaiveDate>,
+    today: NaiveDate,
+) -> Result<Option<NaiveDate>> {
     let data_file = ServiceCatalog::complete_license(service_code)?;
 
     println!("Downloading weekly file...");
@@ -345,7 +503,29 @@ async fn apply_weekly(
     });
 
     let (zip_path, _) = client.download_file(&data_file, progress).await?;
-    let weekly_date = extract_canonical_date(&zip_path)?.unwrap_or_else(|| Utc::now().date_naive());
+    let weekly_date = extract_canonical_date(&zip_path)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "weekly archive {} has no valid FCC creation date",
+            zip_path.display()
+        )
+    })?;
+    if weekly_date > today {
+        bail!(
+            "weekly archive {} has future FCC creation date {} (today is {})",
+            zip_path.display(),
+            weekly_date,
+            today
+        );
+    }
+    if let Some(coverage_date) = newer_than {
+        if weekly_date <= coverage_date {
+            println!(
+                "\nWeekly archive {} does not advance current coverage through {}.",
+                weekly_date, coverage_date
+            );
+            return Ok(None);
+        }
+    }
 
     println!("\nImporting weekly data...");
 
@@ -390,7 +570,7 @@ async fn apply_weekly(
         db.set_last_updated(&date_str)?;
     }
 
-    Ok(weekly_date)
+    Ok(Some(weekly_date))
 }
 
 fn apply_dailies(
@@ -460,14 +640,11 @@ mod tests {
     }
 
     #[test]
-    fn test_weekly_weekday_skip_matches_date() {
-        // FCC weeklies are published on Sundays; a Sunday date should produce
-        // Weekday::Sunday which would be skipped after a fresh weekly import.
+    fn test_weekly_skips_daily_already_covered_by_snapshot() {
+        // A weekly created on Sunday includes Saturday's data, so the Saturday
+        // daily has the same canonical date and is the redundant archive.
         let sunday = NaiveDate::from_ymd_opt(2026, 1, 18).unwrap();
-        assert_eq!(Weekday::for_date(sunday), Weekday::Sunday);
-
-        let monday = NaiveDate::from_ymd_opt(2026, 1, 19).unwrap();
-        assert_eq!(Weekday::for_date(monday), Weekday::Monday);
+        assert_eq!(weekly_covered_daily_weekday(sunday), Weekday::Saturday);
     }
 
     #[test]
@@ -490,6 +667,34 @@ mod tests {
     fn test_weekdays_to_check_none_keeps_all() {
         let kept = weekdays_to_check(None);
         assert_eq!(kept.len(), 7);
+    }
+
+    #[test]
+    fn test_contiguous_patch_coverage_accepts_complete_sequence() {
+        let weekly = NaiveDate::from_ymd_opt(2026, 1, 18).unwrap();
+        let applied = HashSet::from([
+            NaiveDate::from_ymd_opt(2026, 1, 19).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 1, 20).unwrap(),
+        ]);
+
+        assert_eq!(
+            contiguous_patch_coverage(weekly, &applied),
+            Ok(NaiveDate::from_ymd_opt(2026, 1, 20).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_contiguous_patch_coverage_rejects_metadata_gap() {
+        let weekly = NaiveDate::from_ymd_opt(2026, 1, 18).unwrap();
+        let applied = HashSet::from([NaiveDate::from_ymd_opt(2026, 1, 20).unwrap()]);
+
+        assert_eq!(
+            contiguous_patch_coverage(weekly, &applied),
+            Err(DailyGap {
+                missing_date: NaiveDate::from_ymd_opt(2026, 1, 19).unwrap(),
+                next_available_date: NaiveDate::from_ymd_opt(2026, 1, 20).unwrap(),
+            })
+        );
     }
 
     // =========================================================================
@@ -546,6 +751,21 @@ mod tests {
         buf
     }
 
+    fn build_counts_only_zip(creation_date: &str) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let cursor = std::io::Cursor::new(&mut buf);
+            let mut zip = ZipWriter::new(cursor);
+            let opts =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            zip.start_file("counts", opts).unwrap();
+            writeln!(zip, "File Creation Date: {}", creation_date).unwrap();
+            writeln!(zip, "     0 total").unwrap();
+            zip.finish().unwrap();
+        }
+        buf
+    }
+
     /// Mount a ZIP body at the given URL path on the mock server.
     async fn mount_zip(server: &MockServer, url_path: &str, body: Vec<u8>) {
         Mock::given(method("GET"))
@@ -569,10 +789,102 @@ mod tests {
     }
 
     fn test_client(server: &MockServer, cache: &Path) -> FccClient {
-        let config = DownloadConfig::with_cache_dir(cache.to_path_buf())
+        let mut config = DownloadConfig::with_cache_dir(cache.to_path_buf())
             .with_base_url(server.uri())
             .with_timeout(std::time::Duration::from_secs(10));
+        config.max_retries = 0;
         FccClient::new(config).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_build_daily_chain_rejects_future_archive_date() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let client = test_client(&server, tmp.path());
+
+        mount_zip(
+            &server,
+            "/daily/l_am_mon.zip",
+            build_fixture_zip("l_amat", "Tue Jan 20 08:00:00 EST 2026"),
+        )
+        .await;
+
+        let error = build_daily_chain(
+            &client,
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 1, 18).unwrap(),
+            &HashSet::new(),
+            NaiveDate::from_ymd_opt(2026, 1, 19).unwrap(),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("future FCC creation date"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_daily_chain_propagates_server_errors() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let client = test_client(&server, tmp.path());
+
+        Mock::given(method("GET"))
+            .and(wm_path("/daily/l_am_sun.zip"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let error = build_daily_chain(
+            &client,
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 1, 18).unwrap(),
+            &HashSet::new(),
+            NaiveDate::from_ymd_opt(2026, 1, 19).unwrap(),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("server error 503"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_weekly_rejects_future_archive_date() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Tue Jan 20 08:00:00 EST 2026"),
+        )
+        .await;
+
+        let error = apply_weekly(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            None,
+            NaiveDate::from_ymd_opt(2026, 1, 19).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("future FCC creation date"),
+            "unexpected error: {error:#}"
+        );
+        assert!(db.get_last_weekly_date("HA").unwrap().is_none());
     }
 
     #[tokio::test]
@@ -582,13 +894,19 @@ mod tests {
         let db = fresh_db(tmp.path());
         let client = test_client(&server, tmp.path());
 
-        // Weekly published Sunday 2026-01-18. FCC stamps each daily the next
-        // morning, so the Monday daily (data 2026-01-19) is created Tue
-        // 2026-01-20.
+        // Weekly published Sunday 2026-01-18 includes data through Saturday.
+        // FCC stamps each daily the next morning, so Sunday data is canonical
+        // Monday 2026-01-19 and Monday data is canonical Tuesday 2026-01-20.
         mount_zip(
             &server,
             "/complete/l_amat.zip",
             build_fixture_zip("l_amat", "Sun Jan 18 12:01:25 EST 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_sun.zip",
+            build_counts_only_zip("Mon Jan 19 08:00:00 EST 2026"),
         )
         .await;
         mount_zip(
@@ -611,34 +929,58 @@ mod tests {
         .unwrap();
 
         match result {
-            UpdateResult::Updated { dailies, weekly } => {
+            UpdateResult::Updated {
+                dailies, weekly, ..
+            } => {
                 assert!(weekly, "weekly should be applied on a fresh DB");
-                assert_eq!(dailies, 1, "exactly the Monday daily should apply");
+                assert_eq!(dailies, 2, "Sunday and Monday dailies should apply");
             }
             other => panic!("expected Updated, got {:?}", DebugResult(&other)),
         }
 
-        // Metadata reflects the weekly snapshot and the single applied patch.
+        // Metadata reflects the weekly snapshot and both applied patches.
         assert_eq!(
             db.get_last_weekly_date("HA").unwrap(),
             NaiveDate::from_ymd_opt(2026, 1, 18)
         );
         let patches = db.get_applied_patches("HA").unwrap();
-        assert_eq!(patches.len(), 1);
+        assert_eq!(patches.len(), 2);
         assert_eq!(
-            patches[0].patch_date,
-            NaiveDate::from_ymd_opt(2026, 1, 20).unwrap()
+            patches
+                .iter()
+                .find(|patch| { patch.patch_date == NaiveDate::from_ymd_opt(2026, 1, 19).unwrap() })
+                .and_then(|patch| patch.record_count),
+            Some(0)
         );
+        assert_eq!(
+            patches
+                .iter()
+                .map(|patch| patch.patch_date)
+                .collect::<HashSet<_>>(),
+            HashSet::from([
+                NaiveDate::from_ymd_opt(2026, 1, 19).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 1, 20).unwrap(),
+            ])
+        );
+
+        let retry = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(retry, UpdateResult::UpToDate));
     }
 
     #[tokio::test]
     async fn test_run_update_fresh_weekly_applies_full_daily_week() {
-        // Regression: after a fresh weekly the chain resumes from the day after
-        // the weekly (the weekly subsumes the Sunday daily at D+1), so a full
-        // week of dailies stamped with FCC's data-day+1 convention applies
-        // contiguously instead of tripping a false "chain broken" at the seam
-        // between the weekly (Sun, canonical D) and the Monday daily (canonical
-        // D+2).
+        // Regression: after a fresh weekly the chain starts with the Sunday
+        // daily created on D+1, then continues through the weekday dailies.
         let server = MockServer::start().await;
         let tmp = TempDir::new().unwrap();
         let db = fresh_db(tmp.path());
@@ -650,8 +992,9 @@ mod tests {
             build_fixture_zip("l_amat", "Sun Jan 18 12:01:25 EST 2026"),
         )
         .await;
-        // Each weekday daily is stamped the next morning (data day + 1).
+        // Each daily is stamped the next morning (data day + 1).
         for (day, stamp) in [
+            ("sun", "Mon Jan 19 08:00:00 EST 2026"),
             ("mon", "Tue Jan 20 08:00:00 EST 2026"),
             ("tue", "Wed Jan 21 08:00:00 EST 2026"),
             ("wed", "Thu Jan 22 08:00:00 EST 2026"),
@@ -679,9 +1022,11 @@ mod tests {
         .unwrap();
 
         match result {
-            UpdateResult::Updated { dailies, weekly } => {
+            UpdateResult::Updated {
+                dailies, weekly, ..
+            } => {
                 assert!(weekly, "weekly should be applied on a fresh DB");
-                assert_eq!(dailies, 5, "all five weekday dailies should apply");
+                assert_eq!(dailies, 6, "all six post-weekly dailies should apply");
             }
             other => panic!("expected Updated, got {:?}", DebugResult(&other)),
         }
@@ -696,6 +1041,7 @@ mod tests {
         assert_eq!(
             dates,
             vec![
+                NaiveDate::from_ymd_opt(2026, 1, 19).unwrap(),
                 NaiveDate::from_ymd_opt(2026, 1, 20).unwrap(),
                 NaiveDate::from_ymd_opt(2026, 1, 21).unwrap(),
                 NaiveDate::from_ymd_opt(2026, 1, 22).unwrap(),
@@ -720,7 +1066,7 @@ mod tests {
         // builder gates them all out.
         mount_zip(
             &server,
-            "/daily/l_am_mon.zip",
+            "/daily/l_am_sun.zip",
             build_fixture_zip("l_amat", "Mon Jan 19 12:01:25 EST 2026"),
         )
         .await;
@@ -747,12 +1093,13 @@ mod tests {
         let db = fresh_db(tmp.path());
         let client = test_client(&server, tmp.path());
 
-        // Existing weekly on Sunday; a newer Monday daily is available.
+        // Existing weekly on Sunday; the Sunday daily created Monday is
+        // available.
         let weekly = NaiveDate::from_ymd_opt(2026, 1, 18).unwrap();
         db.set_last_weekly_date("HA", weekly).unwrap();
         mount_zip(
             &server,
-            "/daily/l_am_mon.zip",
+            "/daily/l_am_sun.zip",
             build_fixture_zip("l_amat", "Mon Jan 19 12:01:25 EST 2026"),
         )
         .await;
@@ -770,7 +1117,7 @@ mod tests {
         .unwrap();
 
         match result {
-            UpdateResult::CheckOnly { available } => assert_eq!(available, 1),
+            UpdateResult::CheckOnly { available, .. } => assert_eq!(available, 1),
             other => panic!("expected CheckOnly, got {:?}", DebugResult(&other)),
         }
 
@@ -791,7 +1138,7 @@ mod tests {
             .unwrap();
 
         match result {
-            UpdateResult::CheckOnly { available } => assert_eq!(available, 1),
+            UpdateResult::CheckOnly { available, .. } => assert_eq!(available, 1),
             other => panic!("expected CheckOnly, got {:?}", DebugResult(&other)),
         }
         // Nothing imported.
@@ -809,7 +1156,7 @@ mod tests {
         // served daily is newer than today, so the chain is empty.
         mount_zip(
             &server,
-            "/daily/l_am_mon.zip",
+            "/daily/l_am_sun.zip",
             build_fixture_zip("l_amat", "Mon Jan 19 12:01:25 EST 2026"),
         )
         .await;
@@ -832,6 +1179,356 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_run_update_applies_contiguous_prefix_before_later_gap() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for date in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, date).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+
+        mount_zip(
+            &server,
+            "/daily/l_am_thu.zip",
+            build_fixture_zip("l_amat", "Fri Jul 17 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_wed.zip",
+            build_fixture_zip("l_amat", "Thu Jul 23 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 19 12:01:25 EDT 2026"),
+        )
+        .await;
+
+        let result = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+        match result {
+            UpdateResult::Updated {
+                dailies,
+                weekly,
+                gap: Some(gap),
+            } => {
+                assert_eq!(dailies, 1);
+                assert!(!weekly);
+                assert_eq!(
+                    gap.missing_date,
+                    NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()
+                );
+                assert_eq!(
+                    gap.next_available_date,
+                    NaiveDate::from_ymd_opt(2026, 7, 23).unwrap()
+                );
+            }
+            other => panic!("expected gapped Updated, got {:?}", DebugResult(&other)),
+        }
+
+        let dates: HashSet<_> = db
+            .get_applied_patches("HA")
+            .unwrap()
+            .into_iter()
+            .map(|patch| patch.patch_date)
+            .collect();
+        assert!(dates.contains(&NaiveDate::from_ymd_opt(2026, 7, 17).unwrap()));
+        assert!(!dates.contains(&NaiveDate::from_ymd_opt(2026, 7, 23).unwrap()));
+        assert_eq!(db.get_last_weekly_date("HA").unwrap(), Some(weekly));
+    }
+
+    #[tokio::test]
+    async fn test_run_update_retry_preserves_prefix_when_weekly_is_stale() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for date in 13..=20 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, date).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+
+        mount_zip(
+            &server,
+            "/daily/l_am_wed.zip",
+            build_fixture_zip("l_amat", "Thu Jul 23 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 19 12:01:25 EDT 2026"),
+        )
+        .await;
+
+        let result = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+        match result {
+            UpdateResult::Blocked { gap } => {
+                assert_eq!(
+                    gap.missing_date,
+                    NaiveDate::from_ymd_opt(2026, 7, 21).unwrap()
+                );
+                assert_eq!(
+                    gap.next_available_date,
+                    NaiveDate::from_ymd_opt(2026, 7, 23).unwrap()
+                );
+            }
+            other => panic!("expected Blocked, got {:?}", DebugResult(&other)),
+        }
+        assert_eq!(db.get_last_weekly_date("HA").unwrap(), Some(weekly));
+        assert_eq!(db.get_applied_patches("HA").unwrap().len(), 8);
+    }
+
+    #[tokio::test]
+    async fn test_run_update_invalid_weekly_date_preserves_prefix() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for date in 13..=17 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, date).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+
+        mount_zip(
+            &server,
+            "/daily/l_am_wed.zip",
+            build_fixture_zip("l_amat", "Thu Jul 23 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "not a valid FCC date"),
+        )
+        .await;
+
+        let error = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("no valid FCC creation date"),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(db.get_last_weekly_date("HA").unwrap(), Some(weekly));
+        assert_eq!(db.get_applied_patches("HA").unwrap().len(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_run_update_fresh_weekly_applies_prefix_before_later_gap() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jan 18 12:01:25 EST 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_sun.zip",
+            build_fixture_zip("l_amat", "Mon Jan 19 08:00:00 EST 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_mon.zip",
+            build_fixture_zip("l_amat", "Tue Jan 20 08:00:00 EST 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_thu.zip",
+            build_fixture_zip("l_amat", "Fri Jan 23 08:00:00 EST 2026"),
+        )
+        .await;
+
+        let result = run_update(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            false,
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+
+        match result {
+            UpdateResult::Updated {
+                dailies,
+                weekly,
+                gap: Some(gap),
+            } => {
+                assert!(weekly);
+                assert_eq!(dailies, 2);
+                assert_eq!(
+                    gap.missing_date,
+                    NaiveDate::from_ymd_opt(2026, 1, 21).unwrap()
+                );
+                assert_eq!(
+                    gap.next_available_date,
+                    NaiveDate::from_ymd_opt(2026, 1, 23).unwrap()
+                );
+            }
+            other => panic!("expected gapped Updated, got {:?}", DebugResult(&other)),
+        }
+        let patches = db.get_applied_patches("HA").unwrap();
+        assert_eq!(patches.len(), 2);
+        assert_eq!(
+            patches
+                .iter()
+                .map(|patch| patch.patch_date)
+                .collect::<HashSet<_>>(),
+            HashSet::from([
+                NaiveDate::from_ymd_opt(2026, 1, 19).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 1, 20).unwrap(),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_run_update_daily_only_never_falls_back_across_gap() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 1, 18).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        mount_zip(
+            &server,
+            "/daily/l_am_wed.zip",
+            build_fixture_zip("l_amat", "Thu Jan 22 12:01:25 EST 2026"),
+        )
+        .await;
+
+        let result = run_update(&db, &client, "HA", &ImportMode::Minimal, false, true, false)
+            .await
+            .unwrap();
+
+        assert!(matches!(result, UpdateResult::Blocked { .. }));
+        assert_eq!(db.get_last_weekly_date("HA").unwrap(), Some(weekly));
+        assert!(db.get_applied_patches("HA").unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_run_update_check_only_reports_safe_prefix_and_gap() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for date in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, date).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        mount_zip(
+            &server,
+            "/daily/l_am_thu.zip",
+            build_fixture_zip("l_amat", "Fri Jul 17 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_wed.zip",
+            build_fixture_zip("l_amat", "Thu Jul 23 08:00:00 EDT 2026"),
+        )
+        .await;
+
+        let result = run_update(&db, &client, "HA", &ImportMode::Minimal, false, false, true)
+            .await
+            .unwrap();
+
+        match result {
+            UpdateResult::CheckOnly {
+                available: 1,
+                gap: Some(gap),
+            } => {
+                assert_eq!(
+                    gap.missing_date,
+                    NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()
+                );
+            }
+            other => panic!("expected gapped CheckOnly, got {:?}", DebugResult(&other)),
+        }
+        assert_eq!(db.get_applied_patches("HA").unwrap().len(), 4);
+    }
+
+    #[tokio::test]
     async fn test_run_update_broken_daily_chain_falls_back_to_weekly() {
         let server = MockServer::start().await;
         let tmp = TempDir::new().unwrap();
@@ -846,7 +1543,7 @@ mod tests {
 
         mount_zip(
             &server,
-            "/daily/l_am_thu.zip",
+            "/daily/l_am_wed.zip",
             build_fixture_zip("l_amat", "Thu Jan 22 12:01:25 EST 2026"),
         )
         .await;
@@ -885,7 +1582,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_run_update_broken_chain_check_only_reports_one() {
+    async fn test_run_update_broken_chain_check_only_reports_gap_without_update() {
         let server = MockServer::start().await;
         let tmp = TempDir::new().unwrap();
         let db = fresh_db(tmp.path());
@@ -895,7 +1592,7 @@ mod tests {
         db.set_last_weekly_date("HA", weekly).unwrap();
         mount_zip(
             &server,
-            "/daily/l_am_thu.zip",
+            "/daily/l_am_wed.zip",
             build_fixture_zip("l_amat", "Thu Jan 22 12:01:25 EST 2026"),
         )
         .await;
@@ -913,7 +1610,16 @@ mod tests {
         .unwrap();
 
         match result {
-            UpdateResult::CheckOnly { available } => assert_eq!(available, 1),
+            UpdateResult::CheckOnly {
+                available,
+                gap: Some(gap),
+            } => {
+                assert_eq!(available, 0);
+                assert_eq!(
+                    gap.missing_date,
+                    NaiveDate::from_ymd_opt(2026, 1, 19).unwrap()
+                );
+            }
             other => panic!("expected CheckOnly, got {:?}", DebugResult(&other)),
         }
         // Old weekly untouched in check mode.
@@ -956,11 +1662,33 @@ mod tests {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             match self.0 {
                 UpdateResult::UpToDate => write!(f, "UpToDate"),
-                UpdateResult::Updated { dailies, weekly } => {
-                    write!(f, "Updated {{ dailies: {}, weekly: {} }}", dailies, weekly)
+                UpdateResult::Updated {
+                    dailies,
+                    weekly,
+                    gap,
+                } => {
+                    write!(
+                        f,
+                        "Updated {{ dailies: {}, weekly: {}, gap: {} }}",
+                        dailies,
+                        weekly,
+                        gap.is_some()
+                    )
                 }
-                UpdateResult::CheckOnly { available } => {
-                    write!(f, "CheckOnly {{ available: {} }}", available)
+                UpdateResult::Blocked { gap } => {
+                    write!(
+                        f,
+                        "Blocked {{ missing: {}, next: {} }}",
+                        gap.missing_date, gap.next_available_date
+                    )
+                }
+                UpdateResult::CheckOnly { available, gap } => {
+                    write!(
+                        f,
+                        "CheckOnly {{ available: {}, gap: {} }}",
+                        available,
+                        gap.is_some()
+                    )
                 }
             }
         }

--- a/crates/uls-cli/src/commands/update.rs
+++ b/crates/uls-cli/src/commands/update.rs
@@ -49,6 +49,17 @@ pub async fn execute(service: &str, force: bool, minimal: bool) -> Result<()> {
 }
 
 pub async fn execute_with_options(options: UpdateOptions) -> Result<()> {
+    let db_path = default_db_path();
+    let download_config = DownloadConfig::with_cache_dir(default_cache_path());
+    execute_with_context(options, &db_path, download_config, Utc::now().date_naive()).await
+}
+
+async fn execute_with_context(
+    options: UpdateOptions,
+    db_path: &Path,
+    download_config: DownloadConfig,
+    today: NaiveDate,
+) -> Result<()> {
     let UpdateOptions {
         service,
         force,
@@ -59,8 +70,6 @@ pub async fn execute_with_options(options: UpdateOptions) -> Result<()> {
         through,
         format,
     } = options;
-    let db_path = default_db_path();
-    let cache_path = default_cache_path();
 
     let service_code = match service.to_lowercase().as_str() {
         "amateur" | "ham" => "HA",
@@ -90,19 +99,12 @@ pub async fn execute_with_options(options: UpdateOptions) -> Result<()> {
         status_message(structured, format!("Database: {}", db_path.display()));
     }
 
-    let download_config = DownloadConfig::with_cache_dir(cache_path);
     let client = FccClient::new(download_config)?;
 
     if plan {
-        let db = open_database_for_planning(&db_path)?;
-        let planned = planner::build_update_plan(
-            &db,
-            &client,
-            service_name,
-            service_code,
-            Utc::now().date_naive(),
-        )
-        .await?;
+        let db = open_database_for_planning(db_path)?;
+        let planned =
+            planner::build_update_plan(&db, &client, service_name, service_code, today).await?;
         println!("{}", serde_json::to_string_pretty(&planned.document)?);
         return Ok(());
     }
@@ -111,15 +113,10 @@ pub async fn execute_with_options(options: UpdateOptions) -> Result<()> {
         // Inspect the current state and all candidate archives before opening
         // the serving database in write mode. An unreachable target must not
         // initialize or migrate the database as a side effect.
-        let planning_db = open_database_for_planning(&db_path)?;
-        let planned = planner::build_update_plan(
-            &planning_db,
-            &client,
-            service_name,
-            service_code,
-            Utc::now().date_naive(),
-        )
-        .await?;
+        let planning_db = open_database_for_planning(db_path)?;
+        let planned =
+            planner::build_update_plan(&planning_db, &client, service_name, service_code, today)
+                .await?;
         if planned.route_to(target).is_none() {
             bail!(
                 "source date {} is not exactly reachable for {}",
@@ -129,7 +126,7 @@ pub async fn execute_with_options(options: UpdateOptions) -> Result<()> {
         }
         drop(planning_db);
 
-        let db = open_database_for_update(&db_path, structured)?;
+        let db = open_database_for_update(db_path, structured)?;
         verify_planned_base(&db, &planned, service_code)?;
         return apply_planned_target(
             &db,
@@ -142,15 +139,18 @@ pub async fn execute_with_options(options: UpdateOptions) -> Result<()> {
         );
     }
 
-    let db = open_database_for_update(&db_path, structured)?;
-    let result = run_update(
+    let db = open_database_for_update(db_path, structured)?;
+    let result = run_update_at(
         &db,
         &client,
         service_code,
         &import_mode,
-        force,
-        daily_only,
-        check_only,
+        RunUpdateOptions {
+            force,
+            daily_only,
+            check_only,
+            today,
+        },
     )
     .await?;
 
@@ -417,6 +417,7 @@ fn print_daily_gap(gap: DailyGap) {
     );
 }
 
+#[cfg(test)]
 async fn run_update(
     db: &Database,
     client: &FccClient,
@@ -426,7 +427,42 @@ async fn run_update(
     daily_only: bool,
     check_only: bool,
 ) -> Result<UpdateResult> {
-    let today = Utc::now().date_naive();
+    run_update_at(
+        db,
+        client,
+        service_code,
+        import_mode,
+        RunUpdateOptions {
+            force,
+            daily_only,
+            check_only,
+            today: Utc::now().date_naive(),
+        },
+    )
+    .await
+}
+
+#[derive(Clone, Copy)]
+struct RunUpdateOptions {
+    force: bool,
+    daily_only: bool,
+    check_only: bool,
+    today: NaiveDate,
+}
+
+async fn run_update_at(
+    db: &Database,
+    client: &FccClient,
+    service_code: &str,
+    import_mode: &ImportMode,
+    options: RunUpdateOptions,
+) -> Result<UpdateResult> {
+    let RunUpdateOptions {
+        force,
+        daily_only,
+        check_only,
+        today,
+    } = options;
     let db_weekly_date = db.get_last_weekly_date(service_code)?;
     let applied_patches: HashSet<NaiveDate> = db
         .get_applied_patches(service_code)?
@@ -997,6 +1033,12 @@ mod tests {
             planner::WeeklyObservationStatus::Unavailable
         );
         assert_eq!(
+            planner::classify_weekly_error(&anyhow::Error::new(DownloadError::Zip(
+                zip::result::ZipError::FileNotFound,
+            ))),
+            planner::WeeklyObservationStatus::InvalidArchive
+        );
+        assert_eq!(
             planner::classify_weekly_error(&anyhow::anyhow!("invalid FCC creation date")),
             planner::WeeklyObservationStatus::InvalidArchive
         );
@@ -1177,12 +1219,207 @@ mod tests {
         db
     }
 
-    fn test_client(server: &MockServer, cache: &Path) -> FccClient {
+    fn test_download_config(server: &MockServer, cache: &Path) -> DownloadConfig {
         let mut config = DownloadConfig::with_cache_dir(cache.to_path_buf())
             .with_base_url(server.uri())
             .with_timeout(std::time::Duration::from_secs(10));
         config.max_retries = 0;
-        FccClient::new(config).unwrap()
+        config
+    }
+
+    fn test_client(server: &MockServer, cache: &Path) -> FccClient {
+        FccClient::new(test_download_config(server, cache)).unwrap()
+    }
+
+    fn default_update_options(service: &str) -> UpdateOptions {
+        UpdateOptions {
+            service: service.to_owned(),
+            force: false,
+            minimal: true,
+            daily_only: false,
+            check_only: false,
+            plan: false,
+            through: None,
+            format: "json".to_owned(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_compatibility_wrapper_rejects_unimplemented_service() {
+        let error = execute("all", false, false).await.unwrap_err();
+        assert_eq!(error.to_string(), "'all' services not yet implemented");
+    }
+
+    #[tokio::test]
+    async fn test_execute_context_plan_is_read_only() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("missing.db");
+        let mut options = default_update_options("amateur");
+        options.plan = true;
+
+        execute_with_context(
+            options,
+            &db_path,
+            test_download_config(&server, &tmp.path().join("cache")),
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !db_path.exists(),
+            "planning must not create the serving database"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_context_unreachable_target_is_read_only() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("missing.db");
+        let mut options = default_update_options("amateur");
+        options.through = NaiveDate::from_ymd_opt(2026, 7, 23);
+
+        let error = execute_with_context(
+            options,
+            &db_path,
+            test_download_config(&server, &tmp.path().join("cache")),
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("source date 2026-07-23 is not exactly reachable for HA"),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            !db_path.exists(),
+            "an unreachable target must not initialize the serving database"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_context_applies_exact_daily_target() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("serving.db");
+        let db = Database::with_config(DatabaseConfig::with_path(&db_path)).unwrap();
+        db.initialize().unwrap();
+        db.set_last_weekly_date("HA", NaiveDate::from_ymd_opt(2026, 7, 12).unwrap())
+            .unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        drop(db);
+
+        mount_zip(
+            &server,
+            "/daily/l_am_thu.zip",
+            build_fixture_zip("l_amat", "Fri Jul 17 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_wed.zip",
+            build_fixture_zip("l_amat", "Thu Jul 23 08:00:00 EDT 2026"),
+        )
+        .await;
+
+        let mut options = default_update_options("amateur");
+        options.through = NaiveDate::from_ymd_opt(2026, 7, 17);
+        execute_with_context(
+            options,
+            &db_path,
+            test_download_config(&server, &tmp.path().join("cache")),
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let db = Database::with_config(DatabaseConfig::with_path(&db_path)).unwrap();
+        assert_eq!(
+            database_source_date(&db, "HA").unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 17)
+        );
+        let applied: HashSet<_> = db
+            .get_applied_patches("HA")
+            .unwrap()
+            .into_iter()
+            .map(|patch| patch.patch_date)
+            .collect();
+        assert!(applied.contains(&NaiveDate::from_ymd_opt(2026, 7, 17).unwrap()));
+        assert!(!applied.contains(&NaiveDate::from_ymd_opt(2026, 7, 23).unwrap()));
+    }
+
+    #[tokio::test]
+    async fn test_execute_context_applies_only_contiguous_prefix() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("serving.db");
+        let db = Database::with_config(DatabaseConfig::with_path(&db_path)).unwrap();
+        db.initialize().unwrap();
+        db.set_last_weekly_date("HA", NaiveDate::from_ymd_opt(2026, 7, 12).unwrap())
+            .unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        drop(db);
+
+        mount_zip(
+            &server,
+            "/daily/l_am_thu.zip",
+            build_fixture_zip("l_amat", "Fri Jul 17 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_wed.zip",
+            build_fixture_zip("l_amat", "Thu Jul 23 08:00:00 EDT 2026"),
+        )
+        .await;
+
+        let mut options = default_update_options("amateur");
+        options.format = "table".to_owned();
+        execute_with_context(
+            options,
+            &db_path,
+            test_download_config(&server, &tmp.path().join("cache")),
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let db = Database::with_config(DatabaseConfig::with_path(&db_path)).unwrap();
+        assert_eq!(
+            database_source_date(&db, "HA").unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 17)
+        );
+        let applied: HashSet<_> = db
+            .get_applied_patches("HA")
+            .unwrap()
+            .into_iter()
+            .map(|patch| patch.patch_date)
+            .collect();
+        assert!(applied.contains(&NaiveDate::from_ymd_opt(2026, 7, 17).unwrap()));
+        assert!(!applied.contains(&NaiveDate::from_ymd_opt(2026, 7, 23).unwrap()));
     }
 
     #[test]
@@ -1270,6 +1507,35 @@ mod tests {
         assert!(
             error.to_string().contains("server error 503"),
             "unexpected error: {error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_daily_chain_rejects_noncontiguous_local_metadata_before_download() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let client = test_client(&server, tmp.path());
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        let applied = HashSet::from([NaiveDate::from_ymd_opt(2026, 7, 14).unwrap()]);
+
+        let chain = build_daily_chain(
+            &client,
+            "HA",
+            weekly,
+            &applied,
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(chain.contiguous.is_empty());
+        assert_eq!(
+            chain.gap,
+            Some(DailyGap {
+                missing_date: NaiveDate::from_ymd_opt(2026, 7, 13).unwrap(),
+                next_available_date: NaiveDate::from_ymd_opt(2026, 7, 14).unwrap(),
+            })
         );
     }
 
@@ -1994,6 +2260,37 @@ mod tests {
             .is_none());
         assert!(db.get_last_weekly_date("HA").unwrap().is_none());
         assert!(db.get_applied_patches("HA").unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_update_plan_rejects_patch_metadata_without_weekly_anchor() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+        db.record_applied_patch(
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 17).unwrap(),
+            "fixture",
+            None,
+            Some(1),
+        )
+        .unwrap();
+
+        let error = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "HA has daily patch metadata but no weekly anchor"
+        );
     }
 
     #[tokio::test]

--- a/crates/uls-cli/src/commands/update.rs
+++ b/crates/uls-cli/src/commands/update.rs
@@ -1,12 +1,13 @@
 //! Update command - download and update the database with differential updates.
 
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
 use chrono::{Datelike, NaiveDate, Utc};
 use indicatif::{ProgressBar, ProgressStyle};
+use serde::Serialize;
 
 use uls_db::{Database, DatabaseConfig, ImportMode, Importer};
 use uls_download::{
@@ -16,21 +17,48 @@ use uls_parser::archive::ZipExtractor;
 
 use crate::config::{default_cache_path, default_db_path};
 
+mod planner;
+
 /// Type alias for import progress callback to reduce type complexity.
 type ImportProgressCallback = Option<Box<dyn Fn(&uls_db::ImportProgress) + Send + Sync>>;
 
-#[allow(dead_code)]
-pub async fn execute(service: &str, force: bool, minimal: bool) -> Result<()> {
-    execute_with_options(service, force, minimal, false, false).await
+pub struct UpdateOptions {
+    pub service: String,
+    pub force: bool,
+    pub minimal: bool,
+    pub daily_only: bool,
+    pub check_only: bool,
+    pub plan: bool,
+    pub through: Option<NaiveDate>,
+    pub format: String,
 }
 
-pub async fn execute_with_options(
-    service: &str,
-    force: bool,
-    minimal: bool,
-    daily_only: bool,
-    check_only: bool,
-) -> Result<()> {
+#[allow(dead_code)]
+pub async fn execute(service: &str, force: bool, minimal: bool) -> Result<()> {
+    execute_with_options(UpdateOptions {
+        service: service.to_owned(),
+        force,
+        minimal,
+        daily_only: false,
+        check_only: false,
+        plan: false,
+        through: None,
+        format: "table".to_owned(),
+    })
+    .await
+}
+
+pub async fn execute_with_options(options: UpdateOptions) -> Result<()> {
+    let UpdateOptions {
+        service,
+        force,
+        minimal,
+        daily_only,
+        check_only,
+        plan,
+        through,
+        format,
+    } = options;
     let db_path = default_db_path();
     let cache_path = default_cache_path();
 
@@ -53,22 +81,68 @@ pub async fn execute_with_options(
         _ => service_code,
     };
 
-    println!("Updating {} database...", service_name);
-    println!("Database: {}", db_path.display());
-
-    let config = DatabaseConfig::with_path(&db_path);
-    let db = Database::with_config(config)?;
-
-    if !db.is_initialized()? {
-        println!("Initializing database...");
-        db.initialize()?;
-    } else {
-        db.migrate_if_needed()?;
+    let structured = matches!(format.as_str(), "json" | "json-pretty");
+    if plan && !structured {
+        bail!("--plan requires --format json");
+    }
+    if !plan {
+        status_message(structured, format!("Updating {} database...", service_name));
+        status_message(structured, format!("Database: {}", db_path.display()));
     }
 
     let download_config = DownloadConfig::with_cache_dir(cache_path);
     let client = FccClient::new(download_config)?;
 
+    if plan {
+        let db = open_database_for_planning(&db_path)?;
+        let planned = planner::build_update_plan(
+            &db,
+            &client,
+            service_name,
+            service_code,
+            Utc::now().date_naive(),
+        )
+        .await?;
+        println!("{}", serde_json::to_string_pretty(&planned.document)?);
+        return Ok(());
+    }
+
+    if let Some(target) = through {
+        // Inspect the current state and all candidate archives before opening
+        // the serving database in write mode. An unreachable target must not
+        // initialize or migrate the database as a side effect.
+        let planning_db = open_database_for_planning(&db_path)?;
+        let planned = planner::build_update_plan(
+            &planning_db,
+            &client,
+            service_name,
+            service_code,
+            Utc::now().date_naive(),
+        )
+        .await?;
+        if planned.route_to(target).is_none() {
+            bail!(
+                "source date {} is not exactly reachable for {}",
+                target,
+                service_code
+            );
+        }
+        drop(planning_db);
+
+        let db = open_database_for_update(&db_path, structured)?;
+        verify_planned_base(&db, &planned, service_code)?;
+        return apply_planned_target(
+            &db,
+            &client,
+            service_code,
+            &import_mode,
+            planned,
+            target,
+            structured,
+        );
+    }
+
+    let db = open_database_for_update(&db_path, structured)?;
     let result = run_update(
         &db,
         &client,
@@ -113,6 +187,185 @@ pub async fn execute_with_options(
     Ok(())
 }
 
+fn initialized_memory_database() -> Result<Database> {
+    let db = Database::with_config(DatabaseConfig::in_memory())?;
+    db.initialize()?;
+    Ok(db)
+}
+
+fn open_database_for_planning(path: &Path) -> Result<Database> {
+    if !path.exists() {
+        return initialized_memory_database();
+    }
+
+    let mut config = DatabaseConfig::with_path(path);
+    config.enable_wal = false;
+    let db = Database::with_config(config)?;
+    if db.is_initialized()? {
+        Ok(db)
+    } else {
+        drop(db);
+        initialized_memory_database()
+    }
+}
+
+fn open_database_for_update(path: &Path, structured: bool) -> Result<Database> {
+    let db = Database::with_config(DatabaseConfig::with_path(path))?;
+    if db.is_initialized()? {
+        db.migrate_if_needed()?;
+    } else {
+        status_message(structured, "Initializing database...");
+        db.initialize()?;
+    }
+    Ok(db)
+}
+
+fn verify_planned_base(
+    db: &Database,
+    planned: &planner::PlannedUpdate,
+    service_code: &str,
+) -> Result<()> {
+    let actual_weekly_date = db.get_last_weekly_date(service_code)?;
+    let actual_source_date = database_source_date(db, service_code)?;
+    if actual_weekly_date != planned.document.current.weekly_date
+        || actual_source_date != planned.document.current.source_date
+    {
+        bail!(
+            "{} database changed while planning (expected weekly/source {:?}/{:?}, found {:?}/{:?})",
+            service_code,
+            planned.document.current.weekly_date,
+            planned.document.current.source_date,
+            actual_weekly_date,
+            actual_source_date
+        );
+    }
+    Ok(())
+}
+
+fn status_message(structured: bool, message: impl std::fmt::Display) {
+    if structured {
+        eprintln!("{message}");
+    } else {
+        println!("{message}");
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateApplyDocument {
+    format: &'static str,
+    format_version: u8,
+    service_code: String,
+    previous_source_date: Option<NaiveDate>,
+    source_date: NaiveDate,
+    target_source_date: NaiveDate,
+    changed: bool,
+    route: &'static str,
+    weekly_applied: bool,
+    daily_updates_applied: usize,
+}
+
+fn apply_planned_target(
+    db: &Database,
+    client: &FccClient,
+    service_code: &str,
+    import_mode: &ImportMode,
+    planned: planner::PlannedUpdate,
+    target: NaiveDate,
+    structured: bool,
+) -> Result<()> {
+    let previous_source_date = planned.document.current.source_date;
+    let route = planned.route_to(target).ok_or_else(|| {
+        anyhow::anyhow!(
+            "source date {} is not exactly reachable for {}",
+            target,
+            service_code
+        )
+    })?;
+
+    let (route_name, weekly_applied, daily_updates_applied) = match route {
+        planner::ApplyRoute::Noop => ("none", false, 0),
+        planner::ApplyRoute::CurrentDailies(dailies) => {
+            let count = apply_dailies(db, service_code, import_mode, &dailies, structured)?;
+            ("daily", false, count)
+        }
+        planner::ApplyRoute::Weekly(route) => {
+            import_weekly_archive(
+                db,
+                client,
+                service_code,
+                import_mode,
+                &route.archive,
+                structured,
+            )?;
+            let count = apply_dailies(db, service_code, import_mode, &route.dailies, structured)?;
+            ("weekly", true, count)
+        }
+    };
+
+    let source_date = database_source_date(db, service_code)?
+        .ok_or_else(|| anyhow::anyhow!("{} has no source date after update", service_code))?;
+    if source_date != target {
+        bail!(
+            "{} reached source date {}, expected exact target {}",
+            service_code,
+            source_date,
+            target
+        );
+    }
+
+    let result = UpdateApplyDocument {
+        format: "uls.update_result",
+        format_version: 1,
+        service_code: service_code.to_owned(),
+        previous_source_date,
+        source_date,
+        target_source_date: target,
+        changed: previous_source_date != Some(source_date),
+        route: route_name,
+        weekly_applied,
+        daily_updates_applied,
+    };
+
+    if structured {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else if result.changed {
+        println!(
+            "\n✓ {} reached FCC source date {} via {}.",
+            service_code, source_date, route_name
+        );
+    } else {
+        println!(
+            "\n✓ {} is already at FCC source date {}.",
+            service_code, source_date
+        );
+    }
+
+    Ok(())
+}
+
+fn database_source_date(db: &Database, service_code: &str) -> Result<Option<NaiveDate>> {
+    let weekly_date = db.get_last_weekly_date(service_code)?;
+    let applied: HashSet<_> = db
+        .get_applied_patches(service_code)?
+        .into_iter()
+        .map(|patch| patch.patch_date)
+        .collect();
+    match weekly_date {
+        Some(date) => contiguous_patch_coverage(date, &applied)
+            .map(Some)
+            .map_err(|gap| {
+                anyhow::anyhow!(
+                    "{} patch metadata is not contiguous: missing {} before {}",
+                    service_code,
+                    gap.missing_date,
+                    gap.next_available_date
+                )
+            }),
+        None if applied.is_empty() => Ok(None),
+        None => bail!("{} has daily patches without a weekly anchor", service_code),
+    }
+}
+
 #[derive(Debug)]
 enum UpdateResult {
     UpToDate,
@@ -136,10 +389,22 @@ struct DailyGap {
     next_available_date: NaiveDate,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct DailyChain {
-    contiguous: Vec<(NaiveDate, PathBuf)>,
+    contiguous: Vec<DailyArchive>,
     gap: Option<DailyGap>,
+}
+
+#[derive(Clone, Debug)]
+struct DailyArchive {
+    date: NaiveDate,
+    path: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct WeeklyArchive {
+    date: NaiveDate,
+    path: PathBuf,
 }
 
 fn print_daily_gap(gap: DailyGap) {
@@ -213,7 +478,7 @@ async fn run_update(
         // Persist independently useful prefix progress before attempting weekly
         // recovery. If a gap remains, the next invocation evaluates the weekly
         // path against the newly advanced coverage date.
-        let count = apply_dailies(db, service_code, import_mode, &chain.contiguous)?;
+        let count = apply_dailies(db, service_code, import_mode, &chain.contiguous, false)?;
         return Ok(UpdateResult::Updated {
             dailies: count,
             weekly: false,
@@ -295,7 +560,6 @@ async fn build_daily_chain(
     today: NaiveDate,
     skip_weekday: Option<uls_download::catalog::Weekday>,
 ) -> Result<DailyChain> {
-    let full_name = ServiceCatalog::full_name(service_code).unwrap_or("amat");
     let chain_anchor = match contiguous_patch_coverage(last_update, applied) {
         Ok(date) => date,
         Err(gap) => {
@@ -305,8 +569,18 @@ async fn build_daily_chain(
             });
         }
     };
+    let inventory = download_daily_inventory(client, service_code, today, skip_weekday).await?;
+    Ok(build_chain_from_inventory(chain_anchor, &inventory))
+}
 
-    let mut available_dailies: Vec<(NaiveDate, PathBuf)> = vec![];
+async fn download_daily_inventory(
+    client: &FccClient,
+    service_code: &str,
+    today: NaiveDate,
+    skip_weekday: Option<uls_download::catalog::Weekday>,
+) -> Result<Vec<DailyArchive>> {
+    let full_name = ServiceCatalog::full_name(service_code).unwrap_or("amat");
+    let mut inventory = Vec::new();
     let weekdays = weekdays_to_check(skip_weekday);
 
     for weekday in &weekdays {
@@ -329,9 +603,10 @@ async fn build_daily_chain(
                         today
                     );
                 }
-                if canonical_date > chain_anchor {
-                    available_dailies.push((canonical_date, path));
-                }
+                inventory.push(DailyArchive {
+                    date: canonical_date,
+                    path,
+                });
             }
             Err(DownloadError::NotFound { .. }) => tracing::debug!(
                 weekday = %weekday.abbrev(),
@@ -341,40 +616,36 @@ async fn build_daily_chain(
         }
     }
 
-    if available_dailies.is_empty() {
-        return Ok(DailyChain {
-            contiguous: vec![],
-            gap: None,
-        });
-    }
+    inventory.sort_by_key(|archive| archive.date);
+    inventory.dedup_by_key(|archive| archive.date);
+    Ok(inventory)
+}
 
-    // Sort by canonical date
-    available_dailies.sort_by_key(|(date, _)| *date);
-
+fn build_chain_from_inventory(chain_anchor: NaiveDate, inventory: &[DailyArchive]) -> DailyChain {
     let mut contiguous = Vec::new();
     let mut expected = chain_anchor;
-    for (date, path) in available_dailies {
-        if date <= expected {
+    for archive in inventory {
+        if archive.date <= expected {
             continue;
         }
         let next_expected = expected.succ_opt().unwrap_or(expected);
-        if date > next_expected {
-            return Ok(DailyChain {
+        if archive.date > next_expected {
+            return DailyChain {
                 contiguous,
                 gap: Some(DailyGap {
                     missing_date: next_expected,
-                    next_available_date: date,
+                    next_available_date: archive.date,
                 }),
-            });
+            };
         }
-        expected = date;
-        contiguous.push((date, path));
+        expected = archive.date;
+        contiguous.push(archive.clone());
     }
 
-    Ok(DailyChain {
+    DailyChain {
         contiguous,
         gap: None,
-    })
+    }
 }
 
 fn contiguous_patch_coverage(
@@ -468,7 +739,7 @@ async fn apply_weekly_then_dailies(
     let skip = Some(weekly_covered_daily_weekday(weekly_date));
     let chain = build_daily_chain(client, service_code, weekly_date, &applied, today, skip).await?;
 
-    let daily_count = apply_dailies(db, service_code, import_mode, &chain.contiguous)?;
+    let daily_count = apply_dailies(db, service_code, import_mode, &chain.contiguous, false)?;
 
     Ok(Some(UpdateResult::Updated {
         dailies: daily_count,
@@ -485,8 +756,6 @@ async fn apply_weekly(
     newer_than: Option<NaiveDate>,
     today: NaiveDate,
 ) -> Result<Option<NaiveDate>> {
-    let data_file = ServiceCatalog::complete_license(service_code)?;
-
     println!("Downloading weekly file...");
     let pb = ProgressBar::new(100);
     pb.set_style(
@@ -502,35 +771,66 @@ async fn apply_weekly(
         }
     });
 
-    let (zip_path, _) = client.download_file(&data_file, progress).await?;
-    let weekly_date = extract_canonical_date(&zip_path)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "weekly archive {} has no valid FCC creation date",
-            zip_path.display()
-        )
-    })?;
-    if weekly_date > today {
-        bail!(
-            "weekly archive {} has future FCC creation date {} (today is {})",
-            zip_path.display(),
-            weekly_date,
-            today
-        );
-    }
+    let archive = download_weekly_archive(client, service_code, today, progress).await?;
     if let Some(coverage_date) = newer_than {
-        if weekly_date <= coverage_date {
+        if archive.date <= coverage_date {
             println!(
                 "\nWeekly archive {} does not advance current coverage through {}.",
-                weekly_date, coverage_date
+                archive.date, coverage_date
             );
             return Ok(None);
         }
     }
 
-    println!("\nImporting weekly data...");
+    import_weekly_archive(db, client, service_code, import_mode, &archive, false)?;
+    Ok(Some(archive.date))
+}
+
+async fn inspect_weekly_archive(
+    client: &FccClient,
+    service_code: &str,
+    today: NaiveDate,
+) -> Result<WeeklyArchive> {
+    download_weekly_archive(client, service_code, today, Arc::new(|_| {})).await
+}
+
+async fn download_weekly_archive(
+    client: &FccClient,
+    service_code: &str,
+    today: NaiveDate,
+    progress: ProgressCallback,
+) -> Result<WeeklyArchive> {
+    let data_file = ServiceCatalog::complete_license(service_code)?;
+    let (path, _) = client.download_file(&data_file, progress).await?;
+    let date = extract_canonical_date(&path)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "weekly archive {} has no valid FCC creation date",
+            path.display()
+        )
+    })?;
+    if date > today {
+        bail!(
+            "weekly archive {} has future FCC creation date {} (today is {})",
+            path.display(),
+            date,
+            today
+        );
+    }
+    Ok(WeeklyArchive { date, path })
+}
+
+fn import_weekly_archive(
+    db: &Database,
+    client: &FccClient,
+    service_code: &str,
+    import_mode: &ImportMode,
+    archive: &WeeklyArchive,
+    structured: bool,
+) -> Result<()> {
+    status_message(structured, "\nImporting weekly data...");
 
     // Count total records for progress bar
-    let mut extractor = ZipExtractor::open(&zip_path)?;
+    let mut extractor = ZipExtractor::open(&archive.path)?;
     let counts = extractor.count_all_records()?;
     let total_records: usize = counts.values().sum();
 
@@ -547,52 +847,63 @@ async fn apply_weekly(
 
     let importer = Importer::new(db);
     let stats = importer.import_for_service(
-        &zip_path,
+        &archive.path,
         service_code,
         import_mode.clone(),
         import_progress,
     )?;
 
-    println!(
-        "\nImported {} records in {:.1}s",
-        stats.records, stats.duration_secs
+    status_message(
+        structured,
+        format!(
+            "\nImported {} records in {:.1}s",
+            stats.records, stats.duration_secs
+        ),
     );
 
     // Update metadata
+    let data_file = ServiceCatalog::complete_license(service_code)?;
     let etag = client.get_cached_etag(&data_file);
     if let Some(e) = etag {
         db.set_imported_etag(service_code, &e)?;
     }
-    db.set_last_weekly_date(service_code, weekly_date)?;
+    db.set_last_weekly_date(service_code, archive.date)?;
     db.clear_applied_patches(service_code)?;
 
-    if let Some(date_str) = ZipExtractor::open(&zip_path)?.get_file_creation_date() {
+    if let Some(date_str) = ZipExtractor::open(&archive.path)?.get_file_creation_date() {
         db.set_last_updated(&date_str)?;
     }
 
-    Ok(Some(weekly_date))
+    Ok(())
 }
 
 fn apply_dailies(
     db: &Database,
     service_code: &str,
     import_mode: &ImportMode,
-    dailies: &[(NaiveDate, PathBuf)],
+    dailies: &[DailyArchive],
+    structured: bool,
 ) -> Result<usize> {
     let importer = Importer::new(db);
     let mut count = 0;
 
-    for (date, path) in dailies {
-        print!("  Applying {}... ", date);
-        let stats = importer.import_patch(path, import_mode.clone(), None)?;
-        println!("{} records", stats.records);
+    for archive in dailies {
+        if !structured {
+            print!("  Applying {}... ", archive.date);
+        }
+        let stats = importer.import_patch(&archive.path, import_mode.clone(), None)?;
+        if structured {
+            eprintln!("Applying {}: {} records", archive.date, stats.records);
+        } else {
+            println!("{} records", stats.records);
+        }
 
         // Update tracking
-        if let Some(date_str) = ZipExtractor::open(path)?.get_file_creation_date() {
+        if let Some(date_str) = ZipExtractor::open(&archive.path)?.get_file_creation_date() {
             db.set_last_updated(&date_str)?;
         }
 
-        let weekday = match date.weekday() {
+        let weekday = match archive.date.weekday() {
             chrono::Weekday::Mon => "mon",
             chrono::Weekday::Tue => "tue",
             chrono::Weekday::Wed => "wed",
@@ -602,7 +913,13 @@ fn apply_dailies(
             chrono::Weekday::Sun => "sun",
         };
 
-        db.record_applied_patch(service_code, *date, weekday, None, Some(stats.records))?;
+        db.record_applied_patch(
+            service_code,
+            archive.date,
+            weekday,
+            None,
+            Some(stats.records),
+        )?;
         count += 1;
     }
 
@@ -637,6 +954,63 @@ mod tests {
         assert!(parse_fcc_date("not a date").is_none());
         assert!(parse_fcc_date("").is_none());
         assert!(parse_fcc_date("Mon Xyz 01 00:00:00 EST 2025").is_none());
+    }
+
+    #[test]
+    fn test_planning_missing_database_does_not_create_it() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("missing.db");
+
+        let db = open_database_for_planning(&path).unwrap();
+        assert!(db.is_initialized().unwrap());
+        drop(db);
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn test_planning_uninitialized_database_does_not_initialize_it() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("empty.db");
+        fs::write(&path, []).unwrap();
+
+        let db = open_database_for_planning(&path).unwrap();
+        assert!(db.is_initialized().unwrap());
+        drop(db);
+
+        assert_eq!(fs::read(&path).unwrap(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn test_weekly_observation_error_classification_is_stable() {
+        assert_eq!(
+            planner::classify_weekly_error(&anyhow::Error::new(DownloadError::NotFound {
+                url: "https://example.invalid/weekly.zip".to_owned(),
+            })),
+            planner::WeeklyObservationStatus::NotPublished
+        );
+        assert_eq!(
+            planner::classify_weekly_error(&anyhow::Error::new(DownloadError::ServerError {
+                status: 503,
+                url: "https://example.invalid/weekly.zip".to_owned(),
+            })),
+            planner::WeeklyObservationStatus::Unavailable
+        );
+        assert_eq!(
+            planner::classify_weekly_error(&anyhow::anyhow!("invalid FCC creation date")),
+            planner::WeeklyObservationStatus::InvalidArchive
+        );
+        assert_eq!(
+            planner::classify_daily_error(&anyhow::Error::new(DownloadError::ServerError {
+                status: 503,
+                url: "https://example.invalid/daily.zip".to_owned(),
+            })),
+            planner::DailyObservationStatus::Unavailable
+        );
+        assert_eq!(
+            planner::classify_daily_error(&anyhow::anyhow!("invalid FCC creation date")),
+            planner::DailyObservationStatus::InvalidArchive
+        );
     }
 
     #[test]
@@ -766,6 +1140,21 @@ mod tests {
         buf
     }
 
+    fn write_malformed_patch(path: &Path) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let opts = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+        zip.start_file("counts", opts).unwrap();
+        writeln!(zip, "File Creation Date: Fri Jul 17 08:00:00 EDT 2026").unwrap();
+
+        zip.start_file("HD.dat", opts).unwrap();
+        zip.write_all(&fs::read(fixture_dir("l_amat").join("HD.dat")).unwrap())
+            .unwrap();
+        zip.write_all(&[0xff, b'\n']).unwrap();
+        zip.finish().unwrap();
+    }
+
     /// Mount a ZIP body at the given URL path on the mock server.
     async fn mount_zip(server: &MockServer, url_path: &str, body: Vec<u8>) {
         Mock::given(method("GET"))
@@ -794,6 +1183,35 @@ mod tests {
             .with_timeout(std::time::Duration::from_secs(10));
         config.max_retries = 0;
         FccClient::new(config).unwrap()
+    }
+
+    #[test]
+    fn test_apply_dailies_failed_import_does_not_record_patch() {
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        db.set_last_updated("before-patch").unwrap();
+        let patch_path = tmp.path().join("malformed-patch.zip");
+        write_malformed_patch(&patch_path);
+
+        let error = apply_dailies(
+            &db,
+            "HA",
+            &ImportMode::Minimal,
+            &[DailyArchive {
+                date: NaiveDate::from_ymd_opt(2026, 7, 17).unwrap(),
+                path: patch_path,
+            }],
+            true,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("parser error"));
+        assert_eq!(db.get_stats().unwrap().total_licenses, 0);
+        assert!(db.get_applied_patches("HA").unwrap().is_empty());
+        assert_eq!(
+            db.get_last_updated().unwrap().as_deref(),
+            Some("before-patch")
+        );
     }
 
     #[tokio::test]
@@ -885,6 +1303,702 @@ mod tests {
             "unexpected error: {error:#}"
         );
         assert!(db.get_last_weekly_date("HA").unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_plan_reports_prefix_and_gap_without_mutation() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        mount_zip(
+            &server,
+            "/daily/l_am_thu.zip",
+            build_fixture_zip("l_amat", "Fri Jul 17 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_wed.zip",
+            build_fixture_zip("l_amat", "Thu Jul 23 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 12 12:01:25 EDT 2026"),
+        )
+        .await;
+
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            plan.document.reachable_source_dates,
+            vec![
+                NaiveDate::from_ymd_opt(2026, 7, 16).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 17).unwrap(),
+            ]
+        );
+        assert_eq!(
+            plan.document.recommended_source_date,
+            NaiveDate::from_ymd_opt(2026, 7, 17)
+        );
+        let gap = plan.document.current_daily_gap.unwrap();
+        assert_eq!(
+            gap.missing_date,
+            NaiveDate::from_ymd_opt(2026, 7, 18).unwrap()
+        );
+        assert_eq!(
+            gap.next_available_date,
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap()
+        );
+        assert!(matches!(
+            plan.route_to(NaiveDate::from_ymd_opt(2026, 7, 17).unwrap()),
+            Some(planner::ApplyRoute::CurrentDailies(_))
+        ));
+        assert_eq!(db.get_last_weekly_date("HA").unwrap(), Some(weekly));
+        assert_eq!(db.get_applied_patches("HA").unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_update_plan_exposes_disjoint_weekly_route() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        db.set_last_weekly_date("HA", NaiveDate::from_ymd_opt(2026, 7, 12).unwrap())
+            .unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 19 12:01:25 EDT 2026"),
+        )
+        .await;
+        for (weekday, stamp) in [
+            ("sun", "Mon Jul 20 08:00:00 EDT 2026"),
+            ("mon", "Tue Jul 21 08:00:00 EDT 2026"),
+            ("tue", "Wed Jul 22 08:00:00 EDT 2026"),
+            ("wed", "Thu Jul 23 08:00:00 EDT 2026"),
+        ] {
+            mount_zip(
+                &server,
+                &format!("/daily/l_am_{weekday}.zip"),
+                build_fixture_zip("l_amat", stamp),
+            )
+            .await;
+        }
+
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            plan.document.reachable_source_dates,
+            vec![
+                NaiveDate::from_ymd_opt(2026, 7, 16).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 19).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 20).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 21).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 22).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+            ]
+        );
+        assert!(matches!(
+            plan.route_to(NaiveDate::from_ymd_opt(2026, 7, 21).unwrap()),
+            Some(planner::ApplyRoute::Weekly(_))
+        ));
+        let gap = plan.document.current_daily_gap.unwrap();
+        assert_eq!(
+            gap.missing_date,
+            NaiveDate::from_ymd_opt(2026, 7, 17).unwrap()
+        );
+        assert_eq!(
+            gap.next_available_date,
+            NaiveDate::from_ymd_opt(2026, 7, 20).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_plan_preserves_daily_route_when_weekly_is_unavailable() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        mount_zip(
+            &server,
+            "/daily/l_am_thu.zip",
+            build_fixture_zip("l_amat", "Fri Jul 17 08:00:00 EDT 2026"),
+        )
+        .await;
+
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            plan.document.reachable_source_dates,
+            vec![
+                NaiveDate::from_ymd_opt(2026, 7, 16).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 17).unwrap(),
+            ]
+        );
+        assert_eq!(plan.document.observed.weekly_date, None);
+        assert_eq!(
+            plan.document.observed.weekly_status,
+            planner::WeeklyObservationStatus::NotPublished
+        );
+        assert!(plan.document.observed.complete);
+        assert!(matches!(
+            plan.route_to(NaiveDate::from_ymd_opt(2026, 7, 17).unwrap()),
+            Some(planner::ApplyRoute::CurrentDailies(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_update_plan_preserves_weekly_route_when_daily_observation_fails() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        Mock::given(method("GET"))
+            .and(wm_path("/daily/l_am_wed.zip"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 19 12:01:25 EDT 2026"),
+        )
+        .await;
+
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            plan.document.reachable_source_dates,
+            vec![
+                NaiveDate::from_ymd_opt(2026, 7, 16).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 19).unwrap(),
+            ]
+        );
+        assert_eq!(
+            plan.document.observed.daily_status,
+            planner::DailyObservationStatus::Unavailable
+        );
+        assert!(!plan.document.observed.complete);
+        assert!(matches!(
+            plan.route_to(NaiveDate::from_ymd_opt(2026, 7, 19).unwrap()),
+            Some(planner::ApplyRoute::Weekly(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_exact_update_rejects_database_change_after_planning() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 12 12:01:25 EDT 2026"),
+        )
+        .await;
+
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        db.record_applied_patch(
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 17).unwrap(),
+            "fixture",
+            None,
+            Some(1),
+        )
+        .unwrap();
+
+        let error = verify_planned_base(&db, &plan, "HA").unwrap_err();
+        assert!(error.to_string().contains("changed while planning"));
+    }
+
+    #[test]
+    fn test_update_plan_json_keeps_nullable_contract_fields() {
+        let document = planner::UpdatePlanDocument {
+            format: "uls.update_plan",
+            format_version: 1,
+            service: "amateur".to_owned(),
+            service_code: "HA".to_owned(),
+            current: planner::CurrentCoverage {
+                weekly_date: None,
+                source_date: None,
+            },
+            reachable_source_dates: vec![],
+            recommended_source_date: None,
+            observed: planner::ObservedArchives {
+                weekly_date: None,
+                weekly_status: planner::WeeklyObservationStatus::NotPublished,
+                daily_status: planner::DailyObservationStatus::Complete,
+                complete: true,
+                latest_daily_date: None,
+            },
+            current_daily_gap: None,
+        };
+
+        let value = serde_json::to_value(document).unwrap();
+        assert_eq!(value["format"], "uls.update_plan");
+        assert_eq!(value["format_version"], 1);
+        assert!(value["current"]["weekly_date"].is_null());
+        assert!(value["current"]["source_date"].is_null());
+        assert!(value["recommended_source_date"].is_null());
+        assert!(value["observed"]["weekly_date"].is_null());
+        assert_eq!(value["observed"]["weekly_status"], "not_published");
+        assert_eq!(value["observed"]["daily_status"], "complete");
+        assert_eq!(value["observed"]["complete"], true);
+        assert!(value["observed"]["latest_daily_date"].is_null());
+        assert!(value["current_daily_gap"].is_null());
+    }
+
+    #[tokio::test]
+    async fn test_apply_planned_target_stops_before_later_gap() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        mount_zip(
+            &server,
+            "/daily/l_am_thu.zip",
+            build_fixture_zip("l_amat", "Fri Jul 17 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_wed.zip",
+            build_fixture_zip("l_amat", "Thu Jul 23 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 12 12:01:25 EDT 2026"),
+        )
+        .await;
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        apply_planned_target(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            plan,
+            NaiveDate::from_ymd_opt(2026, 7, 17).unwrap(),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            database_source_date(&db, "HA").unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 17)
+        );
+        let dates: HashSet<_> = db
+            .get_applied_patches("HA")
+            .unwrap()
+            .into_iter()
+            .map(|patch| patch.patch_date)
+            .collect();
+        assert!(!dates.contains(&NaiveDate::from_ymd_opt(2026, 7, 23).unwrap()));
+    }
+
+    #[tokio::test]
+    async fn test_apply_planned_target_current_date_is_noop() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 12 12:01:25 EDT 2026"),
+        )
+        .await;
+
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        apply_planned_target(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            plan,
+            NaiveDate::from_ymd_opt(2026, 7, 16).unwrap(),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(db.get_last_weekly_date("HA").unwrap(), Some(weekly));
+        assert_eq!(db.get_applied_patches("HA").unwrap().len(), 4);
+        assert_eq!(
+            database_source_date(&db, "HA").unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 16)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_planned_target_uses_weekly_route_exactly() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        db.set_last_weekly_date("HA", NaiveDate::from_ymd_opt(2026, 7, 12).unwrap())
+            .unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 19 12:01:25 EDT 2026"),
+        )
+        .await;
+        for (weekday, stamp) in [
+            ("sun", "Mon Jul 20 08:00:00 EDT 2026"),
+            ("mon", "Tue Jul 21 08:00:00 EDT 2026"),
+            ("tue", "Wed Jul 22 08:00:00 EDT 2026"),
+            ("wed", "Thu Jul 23 08:00:00 EDT 2026"),
+        ] {
+            mount_zip(
+                &server,
+                &format!("/daily/l_am_{weekday}.zip"),
+                build_fixture_zip("l_amat", stamp),
+            )
+            .await;
+        }
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        apply_planned_target(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            plan,
+            NaiveDate::from_ymd_opt(2026, 7, 21).unwrap(),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            db.get_last_weekly_date("HA").unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 19)
+        );
+        assert_eq!(
+            database_source_date(&db, "HA").unwrap(),
+            NaiveDate::from_ymd_opt(2026, 7, 21)
+        );
+        let dates: HashSet<_> = db
+            .get_applied_patches("HA")
+            .unwrap()
+            .into_iter()
+            .map(|patch| patch.patch_date)
+            .collect();
+        assert_eq!(
+            dates,
+            HashSet::from([
+                NaiveDate::from_ymd_opt(2026, 7, 20).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 21).unwrap(),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_planned_unreachable_target_does_not_mutate() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        let weekly = NaiveDate::from_ymd_opt(2026, 7, 12).unwrap();
+        db.set_last_weekly_date("HA", weekly).unwrap();
+        for day in 13..=16 {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+        mount_zip(
+            &server,
+            "/daily/l_am_wed.zip",
+            build_fixture_zip("l_amat", "Thu Jul 23 08:00:00 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 12 12:01:25 EDT 2026"),
+        )
+        .await;
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let error = apply_planned_target(
+            &db,
+            &client,
+            "HA",
+            &ImportMode::Minimal,
+            plan,
+            NaiveDate::from_ymd_opt(2026, 7, 18).unwrap(),
+            true,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("not exactly reachable"));
+        assert_eq!(db.get_last_weekly_date("HA").unwrap(), Some(weekly));
+        assert_eq!(db.get_applied_patches("HA").unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_update_plan_bootstraps_from_weekly_route() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        mount_zip(
+            &server,
+            "/complete/l_amat.zip",
+            build_fixture_zip("l_amat", "Sun Jul 19 12:01:25 EDT 2026"),
+        )
+        .await;
+        mount_zip(
+            &server,
+            "/daily/l_am_sun.zip",
+            build_counts_only_zip("Mon Jul 20 08:00:00 EDT 2026"),
+        )
+        .await;
+
+        let plan = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(plan.document.current.source_date, None);
+        assert_eq!(
+            plan.document.reachable_source_dates,
+            vec![
+                NaiveDate::from_ymd_opt(2026, 7, 19).unwrap(),
+                NaiveDate::from_ymd_opt(2026, 7, 20).unwrap(),
+            ]
+        );
+        assert!(db.get_last_weekly_date("HA").unwrap().is_none());
+        assert!(db.get_applied_patches("HA").unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_update_plan_rejects_noncontiguous_local_metadata() {
+        let server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let db = fresh_db(tmp.path());
+        let client = test_client(&server, tmp.path());
+
+        db.set_last_weekly_date("HA", NaiveDate::from_ymd_opt(2026, 7, 12).unwrap())
+            .unwrap();
+        for day in [13, 15] {
+            db.record_applied_patch(
+                "HA",
+                NaiveDate::from_ymd_opt(2026, 7, day).unwrap(),
+                "fixture",
+                None,
+                Some(1),
+            )
+            .unwrap();
+        }
+
+        let error = planner::build_update_plan(
+            &db,
+            &client,
+            "amateur",
+            "HA",
+            NaiveDate::from_ymd_opt(2026, 7, 23).unwrap(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("patch metadata is not contiguous"),
+            "unexpected error: {error:#}"
+        );
     }
 
     #[tokio::test]

--- a/crates/uls-cli/src/commands/update/planner.rs
+++ b/crates/uls-cli/src/commands/update/planner.rs
@@ -199,12 +199,6 @@ pub(super) async fn build_update_plan(
         }
     };
 
-    if current_source_date.is_none() && weekly_observation.is_err() {
-        return Err(weekly_observation
-            .expect_err("checked above")
-            .context("cannot plan an initial database without a valid weekly archive"));
-    }
-
     let weekly_route = weekly_observation.ok().and_then(|archive| {
         let newer_snapshot = current_weekly_date
             .map(|date| archive.date > date)

--- a/crates/uls-cli/src/commands/update/planner.rs
+++ b/crates/uls-cli/src/commands/update/planner.rs
@@ -1,0 +1,287 @@
+use std::collections::{BTreeSet, HashSet};
+
+use anyhow::{bail, Result};
+use chrono::NaiveDate;
+use serde::Serialize;
+use uls_db::Database;
+use uls_download::FccClient;
+
+use super::{
+    build_chain_from_inventory, contiguous_patch_coverage, download_daily_inventory,
+    inspect_weekly_archive, DailyArchive, DailyGap, WeeklyArchive,
+};
+
+const PLAN_FORMAT: &str = "uls.update_plan";
+const PLAN_FORMAT_VERSION: u8 = 1;
+
+#[derive(Debug, Serialize)]
+pub(super) struct UpdatePlanDocument {
+    pub format: &'static str,
+    pub format_version: u8,
+    pub service: String,
+    pub service_code: String,
+    pub current: CurrentCoverage,
+    pub reachable_source_dates: Vec<NaiveDate>,
+    pub recommended_source_date: Option<NaiveDate>,
+    pub observed: ObservedArchives,
+    pub current_daily_gap: Option<GapDocument>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct CurrentCoverage {
+    pub weekly_date: Option<NaiveDate>,
+    pub source_date: Option<NaiveDate>,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct ObservedArchives {
+    pub weekly_date: Option<NaiveDate>,
+    pub weekly_status: WeeklyObservationStatus,
+    pub daily_status: DailyObservationStatus,
+    pub complete: bool,
+    pub latest_daily_date: Option<NaiveDate>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum WeeklyObservationStatus {
+    Available,
+    NotPublished,
+    Unavailable,
+    InvalidArchive,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum DailyObservationStatus {
+    Complete,
+    Unavailable,
+    InvalidArchive,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+pub(super) struct GapDocument {
+    pub missing_date: NaiveDate,
+    pub next_available_date: NaiveDate,
+}
+
+impl From<DailyGap> for GapDocument {
+    fn from(gap: DailyGap) -> Self {
+        Self {
+            missing_date: gap.missing_date,
+            next_available_date: gap.next_available_date,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct WeeklyRoute {
+    pub archive: WeeklyArchive,
+    pub dailies: Vec<DailyArchive>,
+}
+
+#[derive(Debug)]
+pub(super) struct PlannedUpdate {
+    pub document: UpdatePlanDocument,
+    current_source_date: Option<NaiveDate>,
+    current_dailies: Vec<DailyArchive>,
+    weekly_route: Option<WeeklyRoute>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum ApplyRoute {
+    Noop,
+    CurrentDailies(Vec<DailyArchive>),
+    Weekly(WeeklyRoute),
+}
+
+impl PlannedUpdate {
+    pub(super) fn route_to(&self, target: NaiveDate) -> Option<ApplyRoute> {
+        if self.current_source_date == Some(target) {
+            return Some(ApplyRoute::Noop);
+        }
+
+        if let Some(position) = self
+            .current_dailies
+            .iter()
+            .position(|archive| archive.date == target)
+        {
+            return Some(ApplyRoute::CurrentDailies(
+                self.current_dailies[..=position].to_vec(),
+            ));
+        }
+
+        let weekly_route = self.weekly_route.as_ref()?;
+        if weekly_route.archive.date == target {
+            return Some(ApplyRoute::Weekly(WeeklyRoute {
+                archive: weekly_route.archive.clone(),
+                dailies: vec![],
+            }));
+        }
+        weekly_route
+            .dailies
+            .iter()
+            .position(|archive| archive.date == target)
+            .map(|position| {
+                ApplyRoute::Weekly(WeeklyRoute {
+                    archive: weekly_route.archive.clone(),
+                    dailies: weekly_route.dailies[..=position].to_vec(),
+                })
+            })
+    }
+}
+
+pub(super) async fn build_update_plan(
+    db: &Database,
+    client: &FccClient,
+    service: &str,
+    service_code: &str,
+    today: NaiveDate,
+) -> Result<PlannedUpdate> {
+    let current_weekly_date = db.get_last_weekly_date(service_code)?;
+    let applied: HashSet<_> = db
+        .get_applied_patches(service_code)?
+        .into_iter()
+        .map(|patch| patch.patch_date)
+        .collect();
+
+    if current_weekly_date.is_none() && !applied.is_empty() {
+        bail!(
+            "{} has daily patch metadata but no weekly anchor",
+            service_code
+        );
+    }
+
+    let current_source_date = current_weekly_date
+        .map(|weekly_date| {
+            contiguous_patch_coverage(weekly_date, &applied).map_err(|gap| {
+                anyhow::anyhow!(
+                    "{} patch metadata is not contiguous: missing {} before {}",
+                    service_code,
+                    gap.missing_date,
+                    gap.next_available_date
+                )
+            })
+        })
+        .transpose()?;
+
+    let daily_observation = download_daily_inventory(client, service_code, today, None).await;
+    let (inventory, daily_status) = match daily_observation {
+        Ok(inventory) => (inventory, DailyObservationStatus::Complete),
+        Err(error) => {
+            tracing::warn!(
+                service_code,
+                error = %error,
+                "daily archives could not be included in the update plan"
+            );
+            (Vec::new(), classify_daily_error(&error))
+        }
+    };
+    let latest_daily_date = inventory.iter().map(|archive| archive.date).max();
+
+    let current_chain =
+        current_source_date.map(|source_date| build_chain_from_inventory(source_date, &inventory));
+    let current_dailies = current_chain
+        .as_ref()
+        .map(|chain| chain.contiguous.clone())
+        .unwrap_or_default();
+
+    let weekly_observation = inspect_weekly_archive(client, service_code, today).await;
+    let (observed_weekly, weekly_status) = match &weekly_observation {
+        Ok(archive) => (Some(archive.date), WeeklyObservationStatus::Available),
+        Err(error) => {
+            tracing::warn!(
+                service_code,
+                error = %error,
+                "weekly archive could not be included in the update plan"
+            );
+            (None, classify_weekly_error(error))
+        }
+    };
+
+    if current_source_date.is_none() && weekly_observation.is_err() {
+        return Err(weekly_observation
+            .expect_err("checked above")
+            .context("cannot plan an initial database without a valid weekly archive"));
+    }
+
+    let weekly_route = weekly_observation.ok().and_then(|archive| {
+        let newer_snapshot = current_weekly_date
+            .map(|date| archive.date > date)
+            .unwrap_or(true);
+        let non_regressing = current_source_date
+            .map(|date| archive.date >= date)
+            .unwrap_or(true);
+        if !newer_snapshot || !non_regressing {
+            return None;
+        }
+
+        let chain = build_chain_from_inventory(archive.date, &inventory);
+        Some(WeeklyRoute {
+            archive,
+            dailies: chain.contiguous,
+        })
+    });
+
+    let mut reachable = BTreeSet::new();
+    if let Some(date) = current_source_date {
+        reachable.insert(date);
+    }
+    reachable.extend(current_dailies.iter().map(|archive| archive.date));
+    if let Some(route) = &weekly_route {
+        reachable.insert(route.archive.date);
+        reachable.extend(route.dailies.iter().map(|archive| archive.date));
+    }
+    let reachable_source_dates: Vec<_> = reachable.into_iter().collect();
+    let recommended_source_date = reachable_source_dates.last().copied();
+
+    let current_daily_gap = current_chain
+        .as_ref()
+        .and_then(|chain| chain.gap)
+        .map(Into::into);
+
+    Ok(PlannedUpdate {
+        document: UpdatePlanDocument {
+            format: PLAN_FORMAT,
+            format_version: PLAN_FORMAT_VERSION,
+            service: service.to_owned(),
+            service_code: service_code.to_owned(),
+            current: CurrentCoverage {
+                weekly_date: current_weekly_date,
+                source_date: current_source_date,
+            },
+            reachable_source_dates,
+            recommended_source_date,
+            observed: ObservedArchives {
+                weekly_date: observed_weekly,
+                weekly_status,
+                daily_status,
+                complete: matches!(
+                    weekly_status,
+                    WeeklyObservationStatus::Available | WeeklyObservationStatus::NotPublished
+                ) && daily_status == DailyObservationStatus::Complete,
+                latest_daily_date,
+            },
+            current_daily_gap,
+        },
+        current_source_date,
+        current_dailies,
+        weekly_route,
+    })
+}
+
+pub(super) fn classify_daily_error(error: &anyhow::Error) -> DailyObservationStatus {
+    match error.downcast_ref::<uls_download::DownloadError>() {
+        Some(uls_download::DownloadError::Zip(_)) | None => DailyObservationStatus::InvalidArchive,
+        Some(_) => DailyObservationStatus::Unavailable,
+    }
+}
+
+pub(super) fn classify_weekly_error(error: &anyhow::Error) -> WeeklyObservationStatus {
+    match error.downcast_ref::<uls_download::DownloadError>() {
+        Some(uls_download::DownloadError::NotFound { .. }) => WeeklyObservationStatus::NotPublished,
+        Some(uls_download::DownloadError::Zip(_)) => WeeklyObservationStatus::InvalidArchive,
+        Some(_) => WeeklyObservationStatus::Unavailable,
+        None => WeeklyObservationStatus::InvalidArchive,
+    }
+}

--- a/crates/uls-cli/src/commands/update/planner.rs
+++ b/crates/uls-cli/src/commands/update/planner.rs
@@ -233,6 +233,10 @@ pub(super) async fn build_update_plan(
         .as_ref()
         .and_then(|chain| chain.gap)
         .map(Into::into);
+    let archive_observations_complete = matches!(
+        weekly_status,
+        WeeklyObservationStatus::Available | WeeklyObservationStatus::NotPublished
+    ) && daily_status == DailyObservationStatus::Complete;
 
     Ok(PlannedUpdate {
         document: UpdatePlanDocument {
@@ -250,10 +254,7 @@ pub(super) async fn build_update_plan(
                 weekly_date: observed_weekly,
                 weekly_status,
                 daily_status,
-                complete: matches!(
-                    weekly_status,
-                    WeeklyObservationStatus::Available | WeeklyObservationStatus::NotPublished
-                ) && daily_status == DailyObservationStatus::Complete,
+                complete: archive_observations_complete,
                 latest_daily_date,
             },
             current_daily_gap,

--- a/crates/uls-cli/src/main.rs
+++ b/crates/uls-cli/src/main.rs
@@ -10,6 +10,7 @@
 //! ```
 
 use anyhow::Result;
+use chrono::NaiveDate;
 use clap::{Parser, Subcommand};
 use clap_complete::Shell;
 use tracing_subscriber::EnvFilter;
@@ -92,9 +93,25 @@ enum Commands {
         #[arg(long)]
         daily_only: bool,
 
-        /// Check for available updates without downloading
+        /// Check for available updates without changing the database
         #[arg(long)]
         check: bool,
+
+        /// Show the safe update plan without changing the database
+        #[arg(
+            long,
+            conflicts_with_all = ["check", "force", "daily_only", "through"]
+        )]
+        plan: bool,
+
+        /// Update exactly through this FCC source date (YYYY-MM-DD)
+        #[arg(
+            long,
+            value_name = "YYYY-MM-DD",
+            value_parser = parse_iso_date,
+            conflicts_with_all = ["check", "force", "daily_only", "plan"]
+        )]
+        through: Option<NaiveDate>,
     },
 
     /// Look up all licenses by FRN (FCC Registration Number)
@@ -252,6 +269,23 @@ fn looks_like_callsign(s: &str) -> bool {
     chars.iter().all(|c| c.is_ascii_alphanumeric())
 }
 
+fn parse_iso_date(value: &str) -> std::result::Result<NaiveDate, String> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 10
+        || bytes[4] != b'-'
+        || bytes[7] != b'-'
+        || bytes
+            .iter()
+            .enumerate()
+            .any(|(index, byte)| index != 4 && index != 7 && !byte.is_ascii_digit())
+    {
+        return Err("expected a date in YYYY-MM-DD format".to_string());
+    }
+
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map_err(|error| format!("invalid date (expected YYYY-MM-DD): {error}"))
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -316,9 +350,20 @@ async fn main() -> Result<()> {
             minimal,
             daily_only,
             check,
+            plan,
+            through,
         }) => {
-            commands::update::execute_with_options(&service, force, minimal, daily_only, check)
-                .await
+            commands::update::execute_with_options(commands::update::UpdateOptions {
+                service,
+                force,
+                minimal,
+                daily_only,
+                check_only: check,
+                plan,
+                through,
+                format: cli.format.clone(),
+            })
+            .await
         }
         Some(Commands::Frn { frns, service }) => {
             commands::frn::execute(&frns, &service, &cli.format, &staleness_opts).await

--- a/crates/uls-cli/tests/cli_integration.rs
+++ b/crates/uls-cli/tests/cli_integration.rs
@@ -193,6 +193,103 @@ fn test_stats_help() {
         .success();
 }
 
+#[test]
+fn test_update_help_describes_planning_and_bounded_updates() {
+    Command::cargo_bin("uls")
+        .unwrap()
+        .args(["update", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--plan"))
+        .stdout(predicate::str::contains("--through <YYYY-MM-DD>"))
+        .stdout(predicate::str::contains(
+            "Show the safe update plan without changing the database",
+        ))
+        .stdout(predicate::str::contains(
+            "Update exactly through this FCC source date",
+        ));
+}
+
+#[test]
+fn test_update_plan_requires_json_output() {
+    Command::cargo_bin("uls")
+        .unwrap()
+        .args(["update", "--plan"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("--plan requires --format json"));
+}
+
+#[test]
+fn test_update_through_requires_strict_iso_date() {
+    for invalid_date in [
+        "2026-7-03",
+        "2026-07-3",
+        "2026/07/03",
+        "2026-02-30",
+        "not-a-date",
+    ] {
+        Command::cargo_bin("uls")
+            .unwrap()
+            .args(["update", "--through", invalid_date])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("YYYY-MM-DD"));
+    }
+
+    // A valid date reaches command dispatch; the deliberately invalid service
+    // then stops execution before any database or network work begins.
+    Command::cargo_bin("uls")
+        .unwrap()
+        .args(["update", "--service", "invalid", "--through", "2026-07-03"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Unknown service"));
+}
+
+#[test]
+fn test_update_plan_and_through_conflicts_are_rejected() {
+    for args in [
+        vec!["update", "--plan", "--check"],
+        vec!["update", "--plan", "--force"],
+        vec!["update", "--plan", "--daily-only"],
+        vec!["update", "--plan", "--through", "2026-07-03"],
+        vec!["update", "--through", "2026-07-03", "--check"],
+        vec!["update", "--through", "2026-07-03", "--force"],
+        vec!["update", "--through", "2026-07-03", "--daily-only"],
+    ] {
+        Command::cargo_bin("uls")
+            .unwrap()
+            .args(args)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("cannot be used with"));
+    }
+}
+
+#[test]
+fn test_update_minimal_is_allowed_with_plan_and_through() {
+    for args in [
+        vec!["update", "--service", "invalid", "--plan", "--minimal"],
+        vec![
+            "update",
+            "--service",
+            "invalid",
+            "--through",
+            "2026-07-03",
+            "--minimal",
+        ],
+    ] {
+        Command::cargo_bin("uls")
+            .unwrap()
+            .args(args)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Unknown service"));
+    }
+}
+
 // =============================================================================
 // Lookup command tests (with database)
 // =============================================================================

--- a/crates/uls-db/src/importer.rs
+++ b/crates/uls-db/src/importer.rs
@@ -12,7 +12,7 @@ use uls_parser::archive::ZipExtractor;
 
 use crate::bulk_inserter::BulkInserter;
 use crate::schema::Schema;
-use crate::{Database, Result};
+use crate::{Database, DbError, Result};
 
 /// RAII guard that restores database state (indexes and PRAGMAs) on drop.
 ///
@@ -101,7 +101,7 @@ impl ImportStats {
 
     /// Whether the import completed without errors.
     pub fn is_successful(&self) -> bool {
-        self.insert_errors == 0
+        self.parse_errors == 0 && self.insert_errors == 0
     }
 }
 
@@ -244,24 +244,25 @@ impl<'a> Importer<'a> {
         // Create guard to ensure cleanup even on early error return
         let mut guard = ImportGuard::new(&conn);
 
+        guard.mark_pragmas_modified();
         conn.execute_batch(
             "PRAGMA synchronous = OFF;
              PRAGMA journal_mode = MEMORY;
              PRAGMA temp_store = MEMORY;
              PRAGMA cache_size = -64000;",
         )?;
-        guard.mark_pragmas_modified();
 
         // Drop indexes for faster bulk insert (will be recreated after import)
         debug!("Dropping indexes for bulk import performance");
-        Schema::drop_indexes(&conn)?;
         guard.mark_indexes_dropped();
+        Schema::drop_indexes(&conn)?;
 
-        // Begin transaction
-        conn.execute("BEGIN TRANSACTION", [])?;
+        // Use a rollback-on-drop transaction so every early-return path leaves
+        // the database contents unchanged.
+        let transaction = conn.unchecked_transaction()?;
 
         // Create bulk inserter with prepared statements (statements compiled ONCE)
-        let mut inserter = BulkInserter::new(&conn)?;
+        let mut inserter = BulkInserter::new(&transaction)?;
 
         let mut stats = ImportStats {
             files: dat_files.len(),
@@ -343,11 +344,15 @@ impl<'a> Importer<'a> {
             }
         }
 
-        // Drop inserter to release statement borrows before commit
+        // Drop inserter to release statement borrows before closing the transaction.
         drop(inserter);
 
-        // Commit transaction
-        conn.execute("COMMIT", [])?;
+        if !stats.is_successful() {
+            let error = failed_import_error("weekly import", &stats);
+            transaction.rollback()?;
+            return Err(error);
+        }
+        transaction.commit()?;
 
         // Rebuild indexes (this is much faster than maintaining them during insert)
         let index_start = Instant::now();
@@ -391,9 +396,6 @@ impl<'a> Importer<'a> {
         mode: ImportMode,
         progress: Option<ProgressCallback>,
     ) -> Result<ImportStats> {
-        // Clear previous import status for this service
-        self.db.clear_import_status(service)?;
-
         let mut extractor = uls_parser::archive::ZipExtractor::open(zip_path)?;
         let all_dat_files = extractor.list_dat_files();
 
@@ -406,6 +408,10 @@ impl<'a> Importer<'a> {
 
         // Perform the import
         let stats = self.import_zip_with_mode(zip_path, mode, progress)?;
+
+        // Only replace status after the import itself has committed
+        // successfully. A rejected archive must leave prior status intact.
+        self.db.clear_import_status(service)?;
 
         // Record import status for each record type
         // Note: We estimate record counts per type based on file structure
@@ -467,20 +473,14 @@ impl<'a> Importer<'a> {
             dat_files
         );
 
-        // Optimize SQLite but DON'T drop indexes (unlike full import)
+        // Daily patches are small enough to keep the database's normal WAL and
+        // synchronous durability settings. Unlike full imports, do not drop
+        // indexes or weaken durability while applying a patch.
         let conn = self.db.conn()?;
-        conn.execute_batch(
-            "PRAGMA synchronous = OFF;
-             PRAGMA journal_mode = MEMORY;
-             PRAGMA temp_store = MEMORY;
-             PRAGMA cache_size = -64000;",
-        )?;
-
-        // Begin transaction
-        conn.execute("BEGIN TRANSACTION", [])?;
+        let transaction = conn.unchecked_transaction()?;
 
         // Create bulk inserter
-        let mut inserter = BulkInserter::new(&conn)?;
+        let mut inserter = BulkInserter::new(&transaction)?;
 
         let mut stats = ImportStats {
             files: dat_files.len(),
@@ -554,17 +554,15 @@ impl<'a> Importer<'a> {
             }
         }
 
-        // Drop inserter to release statement borrows before commit
+        // Drop inserter to release statement borrows before closing the transaction.
         drop(inserter);
 
-        // Commit transaction
-        conn.execute("COMMIT", [])?;
-
-        // Reset SQLite settings
-        conn.execute_batch(
-            "PRAGMA synchronous = NORMAL;
-             PRAGMA journal_mode = WAL;",
-        )?;
+        if !stats.is_successful() {
+            let error = failed_import_error("daily patch", &stats);
+            transaction.rollback()?;
+            return Err(error);
+        }
+        transaction.commit()?;
 
         stats.duration_secs = start.elapsed().as_secs_f64();
 
@@ -577,6 +575,13 @@ impl<'a> Importer<'a> {
 
         Ok(stats)
     }
+}
+
+fn failed_import_error(kind: &str, stats: &ImportStats) -> DbError {
+    DbError::InvalidData(format!(
+        "{kind} rejected: {} parse error(s), {} insert error(s)",
+        stats.parse_errors, stats.insert_errors
+    ))
 }
 
 #[cfg(test)]
@@ -663,6 +668,12 @@ mod tests {
             ..Default::default()
         };
         assert!(!stats_with_errors.is_successful());
+
+        let stats_with_parse_errors = ImportStats {
+            parse_errors: 1,
+            ..Default::default()
+        };
+        assert!(!stats_with_parse_errors.is_successful());
     }
 
     #[test]

--- a/crates/uls-db/tests/importer_service.rs
+++ b/crates/uls-db/tests/importer_service.rs
@@ -7,7 +7,7 @@ use tempfile::TempDir;
 use zip::write::FileOptions;
 use zip::ZipWriter;
 
-use uls_db::{Database, DatabaseConfig, ImportMode, Importer};
+use uls_db::{Database, DatabaseConfig, DbError, ImportMode, Importer};
 
 fn create_test_db() -> (TempDir, Database) {
     let temp_dir = TempDir::new().unwrap();
@@ -209,9 +209,145 @@ fn test_import_patch_does_not_clear_import_status() {
     assert!(db.has_record_type("HA", "AM").unwrap());
 }
 
+#[test]
+fn test_import_patch_stream_error_rolls_back() {
+    let (temp_dir, db) = create_test_db();
+    let importer = Importer::new(&db);
+    importer
+        .import_for_service(&weekly_zip(&temp_dir), "HA", ImportMode::Full, None)
+        .unwrap();
+
+    let mut malformed = hd_line("100001", "W1WEEK", "C").into_bytes();
+    malformed.extend_from_slice(hd_line("200002", "W2TEMP", "A").as_bytes());
+    malformed.extend_from_slice(&[0xff, b'\n']);
+    let patch = write_zip(
+        &temp_dir,
+        "patch_stream_error.zip",
+        &[("HD.dat", &malformed)],
+    );
+
+    let error = importer
+        .import_patch(&patch, ImportMode::Full, None)
+        .unwrap_err();
+    assert!(matches!(error, DbError::Parser(_)));
+    assert_eq!(
+        db.get_license_by_callsign("W1WEEK")
+            .unwrap()
+            .unwrap()
+            .status,
+        'A'
+    );
+    assert!(db.get_license_by_callsign("W2TEMP").unwrap().is_none());
+
+    // The rolled-back transaction must not poison the pooled connection.
+    let retry = write_zip(
+        &temp_dir,
+        "patch_retry.zip",
+        &[("HD.dat", hd_line("100001", "W1WEEK", "C").as_bytes())],
+    );
+    importer
+        .import_patch(&retry, ImportMode::Full, None)
+        .unwrap();
+    assert_eq!(
+        db.get_license_by_callsign("W1WEEK")
+            .unwrap()
+            .unwrap()
+            .status,
+        'C'
+    );
+}
+
+#[test]
+fn test_import_patch_insert_error_rolls_back() {
+    let (temp_dir, db) = create_test_db();
+    let importer = Importer::new(&db);
+    importer
+        .import_for_service(&weekly_zip(&temp_dir), "HA", ImportMode::Full, None)
+        .unwrap();
+
+    let patch = write_zip(
+        &temp_dir,
+        "patch_insert_error.zip",
+        &[
+            ("HD.dat", hd_line("100001", "W1WEEK", "C").as_bytes()),
+            (
+                "EN.dat",
+                b"EN|999999|||W9ORPHAN|L|L00999999|DOE, JANE|JANE||DOE||||||||||||000|0099999999|I||||||\n",
+            ),
+        ],
+    );
+
+    let error = importer
+        .import_patch(&patch, ImportMode::Full, None)
+        .unwrap_err();
+    assert!(matches!(error, DbError::InvalidData(_)));
+    assert_eq!(
+        db.get_license_by_callsign("W1WEEK")
+            .unwrap()
+            .unwrap()
+            .status,
+        'A'
+    );
+    assert!(db.get_license_by_callsign("W9ORPHAN").unwrap().is_none());
+}
+
 // =============================================================================
 // Error paths
 // =============================================================================
+
+#[test]
+fn test_import_for_service_stream_error_rolls_back_and_preserves_status() {
+    let (temp_dir, db) = create_test_db();
+    let importer = Importer::new(&db);
+    importer
+        .import_for_service(&weekly_zip(&temp_dir), "HA", ImportMode::Full, None)
+        .unwrap();
+    db.mark_imported("HA", "LA", 999).unwrap();
+
+    let mut malformed = hd_line("200002", "W2BAD", "A").into_bytes();
+    malformed.extend_from_slice(hd_line("200003", "W3TEMP", "A").as_bytes());
+    malformed.extend_from_slice(&[0xff, b'\n']);
+    let bad_weekly = write_zip(&temp_dir, "bad_weekly.zip", &[("HD.dat", &malformed)]);
+
+    let error = importer
+        .import_for_service(&bad_weekly, "HA", ImportMode::Full, None)
+        .unwrap_err();
+    assert!(matches!(error, DbError::Parser(_)));
+    assert!(db.get_license_by_callsign("W2BAD").unwrap().is_none());
+    assert!(db.get_license_by_callsign("W3TEMP").unwrap().is_none());
+    assert!(db.get_license_by_callsign("W1WEEK").unwrap().is_some());
+    assert!(db.has_record_type("HA", "LA").unwrap());
+}
+
+#[test]
+fn test_import_for_service_insert_error_rolls_back_and_preserves_status() {
+    let (temp_dir, db) = create_test_db();
+    let importer = Importer::new(&db);
+    importer
+        .import_for_service(&weekly_zip(&temp_dir), "HA", ImportMode::Full, None)
+        .unwrap();
+    db.mark_imported("HA", "LA", 999).unwrap();
+
+    let bad_weekly = write_zip(
+        &temp_dir,
+        "bad_weekly_insert.zip",
+        &[
+            ("HD.dat", hd_line("200002", "W2BAD", "A").as_bytes()),
+            (
+                "EN.dat",
+                b"EN|999999|||W9ORPHAN|L|L00999999|DOE, JANE|JANE||DOE||||||||||||000|0099999999|I||||||\n",
+            ),
+        ],
+    );
+
+    let error = importer
+        .import_for_service(&bad_weekly, "HA", ImportMode::Full, None)
+        .unwrap_err();
+    assert!(matches!(error, DbError::InvalidData(_)));
+    assert!(db.get_license_by_callsign("W2BAD").unwrap().is_none());
+    assert!(db.get_license_by_callsign("W1WEEK").unwrap().is_some());
+    assert!(db.has_record_type("HA", "LA").unwrap());
+}
 
 #[test]
 fn test_import_for_service_bad_zip_errors() {


### PR DESCRIPTION
## Summary

- preserve and apply the longest safe contiguous FCC daily-update prefix instead of discarding usable progress when a later daily file is missing
- add machine-readable JSON update planning plus exact `--through` execution for coordinated consumers
- support a newer weekly snapshot as a safe bridge to an exact target without ever crossing a missing archive
- make full and patch imports transactional so failed imports cannot leave partially mutated databases or patch metadata
- document the planning/bounded-update behavior and add deterministic coverage for gaps, bootstrap, weekly routes, exact targets, rollback, and CLI validation

## Why

FCC weekly and daily archives can be published unevenly. The previous updater treated a later gap as a reason to abandon earlier valid daily files, and downstream services had no race-resistant way to ask two radio services what exact date they could both reach before staging updates. Failed imports also needed a database-level rollback boundary.

This change makes the safe unit explicit: a verified contiguous route to one exact FCC source date. It never jumps across a missing daily archive.

## User and developer impact

Normal `uls update` runs can make safe progress through available dailies while reporting a later gap. Automation can inspect `uls update --plan -f json`, choose a common target, and apply it with `--through YYYY-MM-DD`. Bootstrap without an available weekly archive is represented as a valid pending plan rather than a generic process failure. Unreachable exact targets are rejected before database initialization or migration.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features` (689/689 passed)
- `cargo test --doc --workspace`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo +1.88 check --all --locked`
- `cargo deny check`
- `git diff --check`
- local line coverage: 96.81% overall and 97.58% on changed executable lines
- GitHub Codecov project and patch checks passed

Release note: merge this implementation first. The existing release-plz PR #47 must refresh from the resulting `main` state before it is reviewed and merged.
