### PR TITLE
fix(ci): restore stable Rust checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/uls-query/src/output.rs
+++ b/crates/uls-query/src/output.rs
@@ -185,7 +185,7 @@ fn format_license_csv(license: &License) -> String {
         csv_escape(&license.call_sign),
         csv_escape(&license.display_name()),
         license.status,
-        &license.radio_service,
+        license.radio_service,
         license
             .operator_class
             .map(|c| c.to_string())


### PR DESCRIPTION
## Summary

Restore the two CI gates that began failing on unchanged `main` because external inputs advanced:

- remove a redundant CSV-formatting borrow rejected by Rust/Clippy 1.97
- update `crossbeam-epoch` from 0.9.18 to the RustSec-fixed 0.9.20 release

The code and dependency changes remain separate signed Conventional Commits.

## Root cause

GitHub Actions installs the moving `stable` toolchain, which advanced to Rust/Clippy 1.97 and added `useless_borrows_in_formatting`. Separately, the current RustSec advisory database began rejecting the previously locked `crossbeam-epoch 0.9.18` (`RUSTSEC-2026-0204`). These failures affect current `main` and unrelated open PRs; neither was introduced by the contiguous-update feature.

## Impact

No user-visible output or runtime behavior changes. This PR restores current Clippy and dependency-audit compatibility before the feature PR is updated from `main`.

## Validation

- `cargo fmt --all -- --check`
- `cargo +1.97.0 clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run -p uls-query` (117/117 passed)
- `cargo check --all --locked`
- `cargo deny check`
- `git diff --check`